### PR TITLE
added more specific license label to conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: "https://saturncloud.io/"
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: "Dask Cluster objects in Saturn Cloud"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     maintainer="Saturn Cloud Developers",
     maintainer_email="dev@saturncloud.io",
-    license="BSD",
+    license="BSD-3-Clause",
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
@jsignell for your consideration...I think we should use the more specific license label in this project's conda recipe.

Since we use the 3-clause BSD, this recipe should reflect that. I know `BSD-3-Clause` is a valid label because I just submitted a personal project to `conda-forge` with it a week or two ago, and it's [the label from SPDX](https://spdx.org/licenses/BSD-3-Clause.html).