### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# This file controls default reviewers for dask-saturn code.
+# See https://help.github.com/en/articles/about-code-owners
+# for details
+#
+# Maintainers are encouraged to use their best discretion in
+# setting reviewers on PRs manually, but this file should
+# offer a reasonable automatic best-guess
+
+# catch-all rule (this only gets matched if no rules below match)
+*    @jsignell @jameslamb


### PR DESCRIPTION
@jsignell I want to propose adding `CODEOWNERS`, so that GitHub will automatically assign reviewers when pull requests are created. This is useful for cases like #6 where a non-maintainer (who does not have permission to select reviewers) adds a PR.