### PR TITLE
Make dask_labextension work with SaturnCluster

### DIFF
--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -1,0 +1,45 @@
+from time import sleep
+from datetime import datetime
+from math import ceil
+from random import randrange
+
+
+class ExpBackoff:
+    def __init__(self, wait_timeout=1200, min_sleep=5, max_sleep=60):
+        """
+        Used to generate sleep times with a capped exponential backoff.
+        Jitter reduces contention on the event of multiple clients making
+        these calls at the same time.
+
+        :param wait_timeout: Maximum total time in seconds to wait before timing out
+        :param min_sleep: Minimum amount of time to sleep in seconds
+        :param max_sleep: Maximum time to sleep over one period in seconds
+        :return: Boolean indicating if current wait time is less than wait_timeout
+        """
+        self.wait_timeout = wait_timeout
+        self.max_sleep = max_sleep
+        self.min_sleep = min_sleep
+        self.retries = 0
+
+    def wait(self):
+        if self.retries == 0:
+            self.start_time = datetime.now()
+
+        # Check if timeout has been reached
+        time_delta = (datetime.now() - self.start_time).total_seconds()
+        if time_delta >= self.wait_timeout:
+            return False
+
+        # Generate exp backoff with jitter
+        self.retries += 1
+        backoff = min(self.max_sleep, self.min_sleep * 2 ** self.retries) / 2
+        jitter = randrange(0, ceil(backoff))
+        wait_time = backoff + jitter
+
+        # Make sure we aren't waiting longer than wait_timeout
+        remaining_time = self.wait_timeout - time_delta
+        if remaining_time < wait_time:
+            wait_time = remaining_time
+
+        sleep(wait_time)
+        return True

--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -1,4 +1,4 @@
-from time import sleep
+import asyncio
 from datetime import datetime
 from math import ceil
 from random import randrange
@@ -21,7 +21,7 @@ class ExpBackoff:
         self.min_sleep = min_sleep
         self.retries = 0
 
-    def wait(self):
+    async def wait(self):
         if self.retries == 0:
             self.start_time = datetime.now()
 
@@ -41,5 +41,5 @@ class ExpBackoff:
         if remaining_time < wait_time:
             wait_time = remaining_time
 
-        sleep(wait_time)
+        await asyncio.sleep(wait_time)
         return True

--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -41,5 +41,4 @@ class ExpBackoff:
         if remaining_time < wait_time:
             wait_time = remaining_time
 
-        await asyncio.sleep(wait_time)
-        return True
+        return asyncio.sleep(wait_time)

--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -21,14 +21,14 @@ class ExpBackoff:
         self.min_sleep = min_sleep
         self.retries = 0
 
-    async def wait(self):
+    def wait(self):
         if self.retries == 0:
             self.start_time = datetime.now()
 
         # Check if timeout has been reached
         time_delta = (datetime.now() - self.start_time).total_seconds()
         if time_delta >= self.wait_timeout:
-            return False
+            raise ValueError("Retry in a few minutes. Check status in Saturn User Interface")
 
         # Generate exp backoff with jitter
         self.retries += 1

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -127,11 +127,13 @@ class SaturnCluster(SpecCluster):
                 self._refresh_status()
 
         if self.status in ["running", "ready"]:
+            print(f"Cluster is {self.status}")
             return
         if self.status == "closed":
             raise ValueError("Cluster is closed")
 
         self.status = "starting"
+        print(f"Starting cluster. Status: {self.status}")
 
         cluster_config = {
             "n_workers": self.n_workers,
@@ -201,9 +203,6 @@ class SaturnCluster(SpecCluster):
         if not response.ok:
             raise ValueError(response.reason)
 
-    # async def _close(self):
-    #     raise NotImplementedError
-
     async def _close(self):
         while self.status == "closing":
             await asyncio.sleep(1)
@@ -220,6 +219,7 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     def close(self, timeout=None):
+        # let close fail if there is a RunTimeError - this means the process was killed
         return self.sync(self._close, callback_timeout=timeout)
 
     def __exit__(self, typ, value, traceback):

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -201,6 +201,7 @@ class SaturnCluster(SpecCluster):
 
     async def _close(self):
         print("CLOSING")
+        assert False
         while self.status == "closing":
             await asyncio.sleep(1)
             self._refresh_status()
@@ -220,6 +221,11 @@ class SaturnCluster(SpecCluster):
         if self.close_when_done:
             super().__exit__(typ, value, traceback)
             self._loop_runner.stop()
+
+    async def __aexit__(self, typ, value, traceback):
+        print("AEXITING")
+        if self.close_when_done:
+            await self.close()
 
 
 def _options():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -123,7 +123,7 @@ class SaturnCluster(SpecCluster):
             if self.cluster_url is not None:
                 self._refresh_status()
             else:
-                if not expBackoff.wait():
+                if not await expBackoff.wait():
                     raise ValueError(
                         "Retry in a few minutes. Check status in Saturn User Interface"
                     )

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -117,13 +117,10 @@ class SaturnCluster(SpecCluster):
 
         while self.status == "starting":
             print(f"Starting cluster. Status: {self.status}")
+            await expBackoff.wait()
             if self.cluster_url is not None:
                 self._refresh_status()
-            else:
-                if not await expBackoff.wait():
-                    raise ValueError(
-                        "Retry in a few minutes. Check status in Saturn User Interface"
-                    )
+
         if self.status == "running":
             return
         if self.status == "closed":

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -200,10 +200,11 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
 
     async def _close(self):
+        print("CLOSING")
         while self.status == "closing":
             await asyncio.sleep(1)
             self._refresh_status()
-        if self.status in ["stopped", "closed"] or not self.close_when_done:
+        if self.status in ["stopped", "closed"]:
             return
         self.status = "closing"
 
@@ -213,11 +214,6 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
         for pc in self.periodic_callbacks.values():
             pc.stop()
-
-    def close(self, timeout=None):
-        print("CLOSING")
-        self.status = "closing"
-        return super().close(timeout=timeout)
 
     def __exit__(self, typ, value, traceback):
         print("EXITING")

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -2,7 +2,8 @@ import os
 import requests
 import json
 import asyncio
-import atexit
+
+# import atexit
 import weakref
 
 from urllib.parse import urljoin
@@ -237,15 +238,15 @@ class SaturnCluster(SpecCluster):
             await self.close()
 
 
-@atexit.register
-def close_clusters():
-    print("AT EXIT")
-    for cluster in list(SaturnCluster._instances):
-        if not cluster.close_when_done:
-            cluster.status = "closed"
-        elif cluster.status != "closed":
-            raise ValueError
-            cluster.close(timeout=10)
+# @atexit.register
+# def close_clusters():
+#     print("AT EXIT")
+#     for cluster in list(SaturnCluster._instances):
+#         if not cluster.close_when_done:
+#             cluster.status = "closed"
+#         elif cluster.status != "closed":
+#             raise ValueError
+#             cluster.close(timeout=10)
 
 
 def _options():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -2,8 +2,6 @@ import os
 import requests
 import json
 import asyncio
-
-# import atexit
 import weakref
 
 from urllib.parse import urljoin
@@ -203,10 +201,10 @@ class SaturnCluster(SpecCluster):
         if not response.ok:
             raise ValueError(response.reason)
 
-    async def _close(self):
-        raise NotImplementedError
+    # async def _close(self):
+    #     raise NotImplementedError
 
-    async def _close_special(self):
+    async def _close(self):
         while self.status == "closing":
             await asyncio.sleep(1)
             self._refresh_status()
@@ -222,11 +220,7 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     def close(self, timeout=None):
-        try:
-            return self.sync(self._close_special, callback_timeout=timeout)
-        except RuntimeError as err:
-            print("HERE")
-            raise err
+        return self.sync(self._close, callback_timeout=timeout)
 
     def __exit__(self, typ, value, traceback):
         if self.close_when_done:
@@ -236,17 +230,6 @@ class SaturnCluster(SpecCluster):
     async def __aexit__(self, typ, value, traceback):
         if self.close_when_done:
             await self.close()
-
-
-# @atexit.register
-# def close_clusters():
-#     print("AT EXIT")
-#     for cluster in list(SaturnCluster._instances):
-#         if not cluster.close_when_done:
-#             cluster.status = "closed"
-#         elif cluster.status != "closed":
-#             raise ValueError
-#             cluster.close(timeout=10)
 
 
 def _options():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -61,7 +61,7 @@ class SaturnCluster(SpecCluster):
             self.status = response.json()["status"]
         else:
             self._get_pod_status()
- 
+
     def _get_pod_status(self):
         response = requests.get(self.cluster_url[:-1], headers=HEADERS)
         if response.ok:
@@ -211,6 +211,11 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
         for pc in self.periodic_callbacks.values():
             pc.stop()
+
+    def __del__(self):
+        print("IN __DEL__")
+        if self.status != "closed":
+            print("LEAVING OPEN")
 
 
 def _options():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -200,8 +200,6 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
 
     async def _close(self):
-        print("CLOSING")
-        assert False
         while self.status == "closing":
             await asyncio.sleep(1)
             self._refresh_status()
@@ -217,13 +215,11 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     def __exit__(self, typ, value, traceback):
-        print("EXITING")
         if self.close_when_done:
             super().__exit__(typ, value, traceback)
             self._loop_runner.stop()
 
     async def __aexit__(self, typ, value, traceback):
-        print("AEXITING")
         if self.close_when_done:
             await self.close()
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -47,7 +47,7 @@ class SaturnCluster(SpecCluster):
         self.periodic_callbacks = {}
         self._lock = asyncio.Lock()
         self._asynchronous = asynchronous
-        self._instances.add(self)
+        # self._instances.add(self)
         self._correct_state_waiting = None
         self.close_when_done = close_when_done
         self.status = "created"

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -215,8 +215,15 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     def close(self, timeout=None):
+        print("CLOSING")
         self.status = "closing"
         return super().close(timeout=timeout)
+
+    def __exit__(self, typ, value, traceback):
+        print("EXITING")
+        if self.close_when_done:
+            super().__exit__(typ, value, traceback)
+            self._loop_runner.stop()
 
 
 def _options():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -34,22 +34,19 @@ class SaturnCluster(SpecCluster):
         asynchronous=False,
         **kwargs,
     ):
-        if len(self._instances) >= 1:
-            return [i for i in self._instances][0]
-        else:
-            self.n_workers = n_workers
-            self.worker_size = worker_size
-            self.scheduler_size = scheduler_size
-            self.nprocs = nprocs
-            self.nthreads = nthreads
-            self.scheduler_service_wait_timeout = scheduler_service_wait_timeout
-            self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
-            self.loop = self._loop_runner.loop
-            self.periodic_callbacks = {}
-            self._lock = asyncio.Lock()
-            self._asynchronous = asynchronous
-            self._instances.add(self)
-            self._correct_state_waiting = None
+        self.n_workers = n_workers
+        self.worker_size = worker_size
+        self.scheduler_size = scheduler_size
+        self.nprocs = nprocs
+        self.nthreads = nthreads
+        self.scheduler_service_wait_timeout = scheduler_service_wait_timeout
+        self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
+        self.loop = self._loop_runner.loop
+        self.periodic_callbacks = {}
+        self._lock = asyncio.Lock()
+        self._asynchronous = asynchronous
+        self._instances.add(self)
+        self._correct_state_waiting = None
         self.status = "created"
 
         if not self.asynchronous:


### PR DESCRIPTION
I am still working on how to test this locally. But this should allow dask-labextension to work with SaturnCluster. dask-labextension sets all clusters to asynchronous, so we need the `__await__` method. I am less sure about the `start` method.

Related PRs: saturncloud/images#34, https://github.com/saturncloud/saturn/pull/398