### PR TITLE
Add github action to publish to pypi on tag

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -32,5 +32,6 @@ jobs:
       if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1
       with:
-        user: ${{ secrets.pypi_username }}
+        # Password is set in GitHub UI to an API secret for pypi
+        user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,7 +1,8 @@
 name: Publish dask-saturn to pypi on tag
-on: push
-if: startsWith(github.event.ref, 'refs/tags')
-
+on:
+  push:
+    tags:
+      - '*'
 jobs:
   build-and-publish:
     name: Build and publish dask-saturn to PyPI and TestPyPI
@@ -28,6 +29,7 @@ jobs:
         sdist
         bdist_wheel
     - name: Publish distribution to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1
       with:
         user: ${{ secrets.pypi_username }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,34 @@
+name: Publish dask-saturn to pypi on tag
+on: push
+if: startsWith(github.event.ref, 'refs/tags')
+
+jobs:
+  build-and-publish:
+    name: Build and publish dask-saturn to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install build dependencies
+      run: >-
+        python -m
+        pip install
+        setuptools
+        wheel
+        --upgrade
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        setup.py
+        sdist
+        bdist_wheel
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@v1
+      with:
+        user: ${{ secrets.pypi_username }}
+        password: ${{ secrets.pypi_password }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## Releases
+
+Releases are created by pushing a tag on `main` or `release-*` branch:
+
+```
+git tag -a 0.0.3 -m "Release 0.0.3"
+git push --tags
+```
+
+This kicks off a GitHub Action which automatically publishes the package to PyPi.
+
+When that completes, grab the hash from [pypi](https://pypi.org/project/dask-saturn/#files)
+and open a PR to bump that and the version in the conda recipe.
+
+As of writing this, building and uploading the conda package is still a manual process
+that Hugo does.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@ When that completes, grab the hash from [pypi](https://pypi.org/project/dask-sat
 and open a PR to bump that and the version in the conda recipe.
 
 As of writing this, building and uploading the conda package is still a manual process
-that Hugo does.
+that @hhuuggoo does.


### PR DESCRIPTION
I am not sure how to test this. But ideally, when a new version is tagged this should kick off a github action that creates and uploads a package to pypi. 