### PR TITLE
add warnings about missing environment variables

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -1,7 +1,6 @@
 import os
 import requests
 import json
-import warnings
 
 from urllib.parse import urljoin
 from distributed import SpecCluster
@@ -9,13 +8,21 @@ from typing import List, Dict
 
 from .backoff import ExpBackoff
 
-SATURN_TOKEN = os.environ.get("SATURN_TOKEN", "")
-if SATURN_TOKEN == "":
-    warnings.warn("Environment variable SATURN_TOKEN not set", RuntimeWarning)
+try:
+    SATURN_TOKEN = os.environ["SATURN_TOKEN"]
+except KeyError:
+    raise RuntimeError(
+        "Required environment variable SATURN_TOKEN not set. "
+        "dask-saturn code should only be run on Saturn Cloud infrastructure."
+    )
 
-BASE_URL = os.environ.get("BASE_URL", "")
-if BASE_URL == "":
-    warnings.warn("Environment variable BASE_URL not set", RuntimeWarning)
+try:
+    BASE_URL = os.environ["BASE_URL"]
+except KeyError:
+    raise RuntimeError(
+        "Required environment variable BASE_URL not set. "
+        "dask-saturn code should only be run on Saturn Cloud infrastructure."
+    )
 
 HEADERS = {"Authorization": f"token {SATURN_TOKEN}"}
 DEFAULT_WAIT_TIMEOUT_SECONDS = 1200

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -1,6 +1,7 @@
 import os
 import requests
 import json
+import warnings
 
 from urllib.parse import urljoin
 from distributed import SpecCluster
@@ -9,7 +10,13 @@ from typing import List, Dict
 from .backoff import ExpBackoff
 
 SATURN_TOKEN = os.environ.get("SATURN_TOKEN", "")
+if SATURN_TOKEN == "":
+    warnings.warn("Environment variable SATURN_TOKEN not set", RuntimeWarning)
+
 BASE_URL = os.environ.get("BASE_URL", "")
+if BASE_URL == "":
+    warnings.warn("Environment variable BASE_URL not set", RuntimeWarning)
+
 HEADERS = {"Authorization": f"token {SATURN_TOKEN}"}
 DEFAULT_WAIT_TIMEOUT_SECONDS = 1200
 


### PR DESCRIPTION
When creating and managing a cluster backed by Saturn, `dask-saturn` relies on two environment variables: `SATURN_TOKEN` and `BASE_URL`.

These are accessed today with `.get()`. I think the intention in making this lenient is to allow someone to create a `SaturnCluster` object without those variables.

However, I think we should at least warn when they are not set. I just found myself in a situation where `BASE_URL` was not set, and got this error message:

> requests.exceptions.MissingSchema: Invalid URL 'api/dask_clusters': No schema supplied. Perhaps you meant http://api/dask_clusters?

I think this would be confusing for someone who isn't really familiar with `dask-saturn`. Raising a warning would at least give them a good place to start.

## Notes for Reviewers

If I'm wrong about it being desirable to be able to create a `SaturnCluster` even if those environment variables are not set, we should scrap the proposal in this PR and use this pattern:

```python
try:
    SATURN_TOKEN = os.environ["SATURN_TOKEN"]
except KeyError:
    raise RuntimeError("Required environment variable SATURN_TOKEN not set")
```