### PR TITLE
fix flake8 things

### DIFF
--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from math import ceil
 from random import randrange
 
+
 class ExpBackoff:
     def __init__(self, wait_timeout=1200, min_sleep=5, max_sleep=60):
         """
@@ -19,7 +20,7 @@ class ExpBackoff:
         self.max_sleep = max_sleep
         self.min_sleep = min_sleep
         self.retries = 0
-    
+
     def wait(self):
         if self.retries == 0:
             self.start_time = datetime.now()

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -61,7 +61,7 @@ class SaturnCluster(SpecCluster):
         Destroy existing Dask cluster attached to the Jupyter Notebook or
         Custom Deployment and recreate it with the given configuration.
         """
-        print(f"Resetting cluster.")
+        print("Resetting cluster.")
         url = urljoin(BASE_URL, "api/dask_clusters/reset")
         cluster_config = {
             "n_workers": n_workers,


### PR DESCRIPTION
This PR fixes these minor `flake8` things.

```
./dask_saturn/backoff.py:6:1: E302 expected 2 blank lines, found 1
./dask_saturn/backoff.py:22:1: W293 blank line contains whitespace
./dask_saturn/core.py:64:15: F541 f-string is missing placeholders
```
