### PR TITLE
add parameter docs, typehints

### DIFF
--- a/dask_saturn/backoff.py
+++ b/dask_saturn/backoff.py
@@ -5,7 +5,7 @@ from random import randrange
 
 
 class ExpBackoff:
-    def __init__(self, wait_timeout=1200, min_sleep=5, max_sleep=60):
+    def __init__(self, wait_timeout: int = 1200, min_sleep: int = 5, max_sleep: int = 60):
         """
         Used to generate sleep times with a capped exponential backoff.
         Jitter reduces contention on the event of multiple clients making
@@ -21,7 +21,7 @@ class ExpBackoff:
         self.min_sleep = min_sleep
         self.retries = 0
 
-    def wait(self):
+    def wait(self) -> bool:
         if self.retries == 0:
             self.start_time = datetime.now()
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -5,7 +5,7 @@ import logging
 
 from urllib.parse import urljoin
 from distributed import SpecCluster
-from typing import List, Dict
+from typing import Any, Dict, List, Optional
 from sys import stdout
 
 from .backoff import ExpBackoff
@@ -41,17 +41,48 @@ log.addHandler(handler)
 
 
 class SaturnCluster(SpecCluster):
+    """
+    Create a ``SaturnCluster``, an extension of ``distributed.SpecCluster``
+    specific to Saturn Cloud.
+
+    :param n_workers: Number of workers to provision for the cluster. By default,
+        the cluster will start with 0 workers.
+    :param cluster_url: URL for the "cluster" service running in kubernetes. This
+        component of a ``Dask`` cluster in kubernetes knows how to create pods
+        for workers and the scheduler.
+    :param worker_size: A string with the size to use for each worker. A list of
+        valid sizes and their details can be obtained with ``dask_saturn.describe_sizes()``.
+        If no size is provided, this will default to the size configured for Jupyter
+        in your Saturn Cloud project.
+    :param worker_size: A string with the size to use for the scheduler. A list of
+        valid sizes and their details can be obtained with ``dask_saturn.describe_sizes()``.
+        If no size is provided, this will default to the size configured for Jupyter
+        in your Saturn Cloud project.
+    :param nprocs: The number of ``dask-worker`` processes run on each host in a distributed
+        cluster.
+    :param nthreads: The number of vCPUs allocated to each ``dask-worker`` process.
+    :param scheduler_service_wait_timeout: The maximum amout of time, in seconds, that
+        ``SaturnCluster`` will wait for the scheduler to respond before deciding
+        that the scheduler is taking too long. By default, this is set to 1200 (20
+        minutes). Setting it to a lower value will help you catch problems earlier,
+        but may also lead to false positives if you don't give the cluster
+        enough to time to start up.
+    :param autoclose: Whether or not the cluster should be automatically destroyed
+        when its ``__exit__()`` method is called. By default, this is ``False``. Set
+        this parameter to ``True`` if you want to use it in a context manager which
+        closes the cluster when it exits.
+    """
     def __init__(
         self,
         *args,
-        n_workers=None,
-        cluster_url=None,
-        worker_size=None,
-        scheduler_size=None,
-        nprocs=None,
-        nthreads=None,
-        scheduler_service_wait_timeout=DEFAULT_WAIT_TIMEOUT_SECONDS,
-        autoclose=False,
+        n_workers: Optional[int] = None,
+        cluster_url: Optional[str] = None,
+        worker_size: Optional[str] = None,
+        scheduler_size: Optional[str] = None,
+        nprocs: Optional[int] = None,
+        nthreads: Optional[int] = None,
+        scheduler_service_wait_timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
+        autoclose: bool = False,
         **kwargs,
     ):
         if cluster_url is None:
@@ -75,17 +106,20 @@ class SaturnCluster(SpecCluster):
     @classmethod
     def reset(
         cls,
-        n_workers=None,
-        worker_size=None,
-        scheduler_size=None,
-        nprocs=None,
-        nthreads=None,
-        scheduler_service_wait_timeout=DEFAULT_WAIT_TIMEOUT_SECONDS,
-    ):
+        n_workers: Optional[int] = None,
+        worker_size: Optional[str] = None,
+        scheduler_size: Optional[str] = None,
+        nprocs: Optional[int] = None,
+        nthreads: Optional[int] = None,
+        scheduler_service_wait_timeout: Optional[int] = DEFAULT_WAIT_TIMEOUT_SECONDS,
+    ) -> "SaturnCluster":
         """Return a SaturnCluster
 
         Destroy existing Dask cluster attached to the Jupyter Notebook or
         Custom Deployment and recreate it with the given configuration.
+
+        For documentation on this method's parameters, see
+        ``help(SaturnCluster)``.
         """
         log.info("Resetting cluster.")
         url = urljoin(BASE_URL, "api/dask_clusters/reset")
@@ -102,7 +136,7 @@ class SaturnCluster(SpecCluster):
         return cls(**cluster_config)
 
     @property
-    def status(self):
+    def status(self) -> str:
         if self.cluster_url is None:
             return "closed"
         url = urljoin(self.cluster_url, "status")
@@ -111,25 +145,25 @@ class SaturnCluster(SpecCluster):
             return self._get_pod_status()
         return response.json()["status"]
 
-    def _get_pod_status(self):
+    def _get_pod_status(self) -> Optional[str]:
         response = requests.get(self.cluster_url[:-1], headers=HEADERS)
         if response.ok:
             return response.json()["status"]
 
     @property
-    def _supports_scaling(self):
+    def _supports_scaling(self) -> bool:
         return True
 
     @property
-    def scheduler_address(self):
+    def scheduler_address(self) -> str:
         return self._scheduler_address
 
     @property
-    def dashboard_link(self):
+    def dashboard_link(self) -> str:
         return self._dashboard_link
 
     @property
-    def scheduler_info(self):
+    def scheduler_info(self) -> Dict[str, Any]:
         url = urljoin(self.cluster_url, "scheduler_info")
         response = requests.get(url, headers=HEADERS)
         if not response.ok:
@@ -142,14 +176,19 @@ class SaturnCluster(SpecCluster):
 
     def _start(
         self,
-        n_workers=None,
-        worker_size=None,
-        scheduler_size=None,
-        nprocs=None,
-        nthreads=None,
-        scheduler_service_wait_timeout=DEFAULT_WAIT_TIMEOUT_SECONDS,
-    ):
-        """Start a cluster that has already been defined for the project."""
+        n_workers: Optional[int] = None,
+        worker_size: Optional[str] = None,
+        scheduler_size: Optional[str] = None,
+        nprocs: Optional[int] = None,
+        nthreads: Optional[int] = None,
+        scheduler_service_wait_timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
+    ) -> None:
+        """
+        Start a cluster that has already been defined for the project.
+
+        For documentation on this method's parameters, see
+        ``help(SaturnCluster)``.
+        """
         url = urljoin(BASE_URL, "api/dask_clusters")
         self.cluster_url = None
 
@@ -186,21 +225,25 @@ class SaturnCluster(SpecCluster):
                         "Retry in a few minutes. Check status in Saturn User Interface"
                     )
 
-    def _get_info(self):
+    def _get_info(self) -> Dict[str, Any]:
         url = urljoin(self.cluster_url, "info")
         response = requests.get(url, headers=HEADERS)
         if not response.ok:
             raise ValueError(response.reason)
         return response.json()
 
-    def scale(self, n):
-        """Scale cluster to have ``n`` workers"""
+    def scale(self, n: int) -> None:
+        """
+        Scale cluster to have ``n`` workers
+
+        :param n: number of workers to scale to.
+        """
         url = urljoin(self.cluster_url, "scale")
         response = requests.post(url, json.dumps({"n": n}), headers=HEADERS)
         if not response.ok:
             raise ValueError(response.reason)
 
-    def adapt(self, minimum, maximum):
+    def adapt(self, minimum: int, maximum: int) -> None:
         """Adapt cluster to have between ``minimum`` and ``maximum`` workers"""
         url = urljoin(self.cluster_url, "adapt")
         response = requests.post(
@@ -209,7 +252,7 @@ class SaturnCluster(SpecCluster):
         if not response.ok:
             raise ValueError(response.reason)
 
-    def close(self):
+    def close(self) -> None:
         url = urljoin(self.cluster_url, "close")
         response = requests.post(url, headers=HEADERS)
         if not response.ok:
@@ -218,10 +261,10 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     @property
-    def asynchronous():
+    def asynchronous() -> bool:
         return False
 
-    def __enter__(self):
+    def __enter__(self) -> "SaturnCluster":
         assert self.status == "running"
         return self
 
@@ -230,7 +273,7 @@ class SaturnCluster(SpecCluster):
             return self.close()
 
 
-def _options():
+def _options() -> Dict[str, Any]:
     url = urljoin(BASE_URL, "api/dask_clusters/info")
     response = requests.get(url, headers=HEADERS)
     if not response.ok:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -60,7 +60,7 @@ class SaturnCluster(SpecCluster):
         in your Saturn Cloud project.
     :param nprocs: The number of ``dask-worker`` processes run on each host in a distributed
         cluster.
-    :param nthreads: The number of vCPUs allocated to each ``dask-worker`` process.
+    :param nthreads: The number of threads available to each ``dask-worker`` process.
     :param scheduler_service_wait_timeout: The maximum amout of time, in seconds, that
         ``SaturnCluster`` will wait for the scheduler to respond before deciding
         that the scheduler is taking too long. By default, this is set to 1200 (20


### PR DESCRIPTION
This pull requests proposes adding documentation including parameter descriptions and type hints, to improve the user experience with `dask-saturn` and make it easier to choose appropriate values for parameters.

Even though this project  doesn't have hosted documentation, these can still be read in the source code here on GitHub and in any Python REPL via `help(SaturnCluster)`.