### PR TITLE
fix status check for new atlas statuses

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -212,7 +212,7 @@ class SaturnCluster(SpecCluster):
                     log.warning(warning)
             if data["status"] == "error":
                 raise ValueError(" ".join(data["errors"]))
-            elif data["status"] == "running":
+            elif data["status"] in ["ready", "running"]:
                 self.cluster_url = f"{url}/{data['id']}/"
                 log.info("Cluster is running")
                 break

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -212,9 +212,9 @@ class SaturnCluster(SpecCluster):
                     log.warning(warning)
             if data["status"] == "error":
                 raise ValueError(" ".join(data["errors"]))
-            elif data["status"] == "ready":
+            elif data["status"] == "running":
                 self.cluster_url = f"{url}/{data['id']}/"
-                log.info("Cluster is ready")
+                log.info("Cluster is running")
                 break
             else:
                 log.info(f"Starting cluster. Status: {data['status']}")


### PR DESCRIPTION
did a refactor of the statuses in Atlas and reduced everything to a single set of terms. As part of that, everything that had used the status "ready" became "running", and as a result dask-saturn was looking for the wrong status.

Set it up to check for either "ready" or "running" to maintain backwards compatibility, just in case.