### PR TITLE
fix parameter doc and import strategy

### DIFF
--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -1,4 +1,6 @@
 from .core import SaturnCluster
+from .core import describe_sizes
+from .core import list_sizes
 
 from ._version import get_versions
 

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -1,6 +1,5 @@
 from .core import SaturnCluster
-from .core import describe_sizes
-from .core import list_sizes
+from .core import describe_sizes, list_sizes
 
 from ._version import get_versions
 

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -1,6 +1,4 @@
-from .core import SaturnCluster
-from .core import describe_sizes, list_sizes
-
+from .core import describe_sizes, list_sizes, SaturnCluster
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -54,7 +54,7 @@ class SaturnCluster(SpecCluster):
         valid sizes and their details can be obtained with ``dask_saturn.describe_sizes()``.
         If no size is provided, this will default to the size configured for Jupyter
         in your Saturn Cloud project.
-    :param worker_size: A string with the size to use for the scheduler. A list of
+    :param scheduler_size: A string with the size to use for the scheduler. A list of
         valid sizes and their details can be obtained with ``dask_saturn.describe_sizes()``.
         If no size is provided, this will default to the size configured for Jupyter
         in your Saturn Cloud project.


### PR DESCRIPTION
This PR proposes two tiny fixes to improve the usability of `dask-saturn`.

1. Fixes a typo in docs (`scheduler_size` documented as `worker_size`)
2. Adds `describe_sizes()` and `list_sizes()` to `__init__.py`. This allows you to do `from dask_saturn import describe_sizes`, Without this, you have to run `from dask_saturn.core import describe_sizes`.