### PR TITLE
add linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,5 @@ jobs:
         if: matrix.task == 'linting'
         shell: bash
         run: |
-          pip install --upgrade black flake8 mypy pylint
+          pip install --upgrade black flake8 pylint
           make lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Linting and unit tests
+
+# only run this workflow on new commits to main
+# or PRs into main
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  schedule:
+    # Run every Monday morning at 11:00a UTC, 6:00a CST
+    - cron: '0 11 * * 1'
+
+jobs:
+  test:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: linting
+          - task: unit-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        if: matrix.task != 'todo-checks'
+        uses: s-weigand/setup-conda@v1.0.3
+        with:
+          python-version: 3.7
+      - name: linting
+        if: matrix.task == 'linting'
+        shell: bash
+        run: |
+          pip install --upgrade black flake8 mypy pylint
+          make lint
+      - name: unit-tests
+        if: matrix.task == 'unit-tests'
+        shell: bash
+        run: |
+          pip install --upgrade cloudpickle pytest pytest-cov responses
+          make unit-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         include:
           - task: linting
-          - task: unit-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -37,9 +36,3 @@ jobs:
         run: |
           pip install --upgrade black flake8 mypy pylint
           make lint
-      - name: unit-tests
-        if: matrix.task == 'unit-tests'
-        shell: bash
-        run: |
-          pip install --upgrade cloudpickle pytest pytest-cov responses
-          make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ lint:
 	#   * R0914: too many local variables
 	#   * R1705: Unnecessary "else" after "return"
 	#   * R1720: Unnecessary "elif" after "return"
+	#   * W0107: unnecessary "pass" statement
 	#   * W0212: access to protected member
 	#   * W0221: parameters differ from overridden method
 	#   * W1203: use lazy % formatting
-	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0212,W0221,W1203 dask_saturn/
+	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0107,W0212,W0221,W1203 dask_saturn/

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,26 @@
 conda-update:
 	envsubst < environment.yaml > /tmp/environment.yaml
 	conda env update -n dask-saturn --file /tmp/environment.yaml
+
+.PHONY: format
+format:
+	black --line-length 100 .
+
+.PHONY: lint
+lint:
+	flake8 --count --max-line-length 100 --exclude versioneer.py .
+	black --check --diff --line-length 100 .
+	# pylint disables:
+	#   * C0301: line too long
+	#   * C0103: snake-case naming
+	#   * C0330: wrong hanging indent before block
+	#   * E0401: unable to import
+	#   * R0903: too few public methods
+	#   * R0913: too many arguments
+	#   * R0914: too many local variables
+	#   * R1705: Unnecessary "else" after "return"
+	#   * R1720: Unnecessary "elif" after "return"
+	#   * W0212: access to protected member
+	#   * W0221: parameters differ from overridden method
+	#   * W1203: use lazy % formatting
+	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0212,W0221,W1203 dask_saturn/

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -1,4 +1,8 @@
-from .core import describe_sizes, list_sizes, SaturnCluster
+"""
+imports added so users do not have to think about submodules
+"""
+
+from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/dask_saturn/_version.py
+++ b/dask_saturn/_version.py
@@ -1,3 +1,5 @@
+# pylint: disable-all
+
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -251,7 +253,15 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(
         GITS,
-        ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix,],
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
         cwd=root,
     )
     # --long was added in git-1.5.5
@@ -294,7 +304,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix,)
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -101,7 +101,7 @@ class SaturnCluster(SpecCluster):
         **kwargs,
     ):
         if cluster_url is None:
-            await self._start(
+            self._start(
                 n_workers=n_workers,
                 worker_size=worker_size,
                 worker_is_spot=worker_is_spot,
@@ -216,7 +216,8 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
         return response.json()
 
-    async def _start(
+    # pylint: disable=invalid-overridden-method
+    def _start(
         self,
         n_workers: Optional[int] = None,
         worker_size: Optional[str] = None,
@@ -315,8 +316,13 @@ class SaturnCluster(SpecCluster):
         """
         Whether or not the cluster's ``_start`` method
         is synchronous.
+
+        ``SaturnCluster`` uses a synchronous ``_start()``
+        because it has to be called in the class
+        constructor, which is intended to be used interactively
+        in a notebook.
         """
-        return True
+        return False
 
     def __enter__(self) -> "SaturnCluster":
         """

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -86,6 +86,7 @@ class SaturnCluster(SpecCluster):
         closes the cluster when it exits.
     """
 
+    # pylint: disable=unused-argument,super-init-not-called
     def __init__(
         self,
         *args,
@@ -100,7 +101,6 @@ class SaturnCluster(SpecCluster):
         autoclose: bool = False,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
         if cluster_url is None:
             self._start(
                 n_workers=n_workers,
@@ -166,18 +166,6 @@ class SaturnCluster(SpecCluster):
             return self._get_pod_status()
         return response.json()["status"]
 
-    @status.setter
-    def status(self, value) -> None:
-        """
-        Setter to make super-initialization happy when
-        it tries to initialize status.
-
-        This value is ignored. Every time you access ``.status``,
-        it will get the relevant information by hitting
-        the ``/status`` endpoint.
-        """
-        pass
-
     def _get_pod_status(self) -> Optional[str]:
         """
         Status of the KubeCluster pod.
@@ -226,18 +214,6 @@ class SaturnCluster(SpecCluster):
                 raise ValueError("Cluster is not running.")
             raise ValueError(response.reason)
         return response.json()
-
-    @scheduler_info.setter
-    def scheduler_info(self, value) -> None:
-        """
-        Setter to make super-initialization happy when
-        it tries to initialize scheduler_info.
-
-        This value is ignored. Every time you access ``.scheduler_info``,
-        it will get the relevant information by hitting
-        the ``/scheduler_info`` endpoint.
-        """
-        pass
 
     # pylint: disable=invalid-overridden-method
     def _start(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -101,7 +101,7 @@ class SaturnCluster(SpecCluster):
         **kwargs,
     ):
         if cluster_url is None:
-            self._start(
+            await self._start(
                 n_workers=n_workers,
                 worker_size=worker_size,
                 worker_is_spot=worker_is_spot,

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -100,6 +100,7 @@ class SaturnCluster(SpecCluster):
         autoclose: bool = False,
         **kwargs,
     ):
+        super().__init__(*args, **kwargs)
         if cluster_url is None:
             self._start(
                 n_workers=n_workers,
@@ -118,8 +119,6 @@ class SaturnCluster(SpecCluster):
         self.loop = None
         self.periodic_callbacks: Dict[str, PeriodicCallback] = {}
         self.autoclose = autoclose
-
-        super().__init__(*args, **kwargs)
 
     @classmethod
     def reset(
@@ -166,6 +165,18 @@ class SaturnCluster(SpecCluster):
         if not response.ok:
             return self._get_pod_status()
         return response.json()["status"]
+
+    @status.setter
+    def status(self, value) -> None:
+        """
+        Setter to make super-initialization happy when
+        it tries to initialize status.
+
+        This value is ignored. Every time you access ``.status``,
+        it will get the relevant information by hitting
+        the ``/status`` endpoint.
+        """
+        pass
 
     def _get_pod_status(self) -> Optional[str]:
         """
@@ -226,7 +237,7 @@ class SaturnCluster(SpecCluster):
         it will get the relevant information by hitting
         the ``/scheduler_info`` endpoint.
         """
-        self._scheduler_info = value
+        pass
 
     # pylint: disable=invalid-overridden-method
     def _start(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -300,6 +300,9 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
 
     def close(self) -> None:
+        """
+        Defines what should be done when closing the cluster.
+        """
         url = urljoin(self.cluster_url, "close")
         response = requests.post(url, headers=HEADERS)
         if not response.ok:
@@ -309,13 +312,34 @@ class SaturnCluster(SpecCluster):
 
     @property
     def asynchronous(self) -> bool:
-        return False
+        """
+        Whether or not the cluster's ``_start`` method
+        is synchronous.
+        """
+        return True
 
     def __enter__(self) -> "SaturnCluster":
+        """
+        magic method used to allow the use of ``SaturnCluster``
+        with a context manager.
+
+        .. code-block:: python
+
+            with SaturnCluster() as cluster:
+        """
         assert self.status == "running"
         return self
 
     def __exit__(self, typ, value, traceback) -> None:
+        """
+        magic method thate defines what should be done
+        when exiting a context manager's context. in other words
+        at the end of this
+
+        .. code-block:: python
+
+            with SaturnCluster() as cluster:
+        """
         if self.autoclose:
             self.close()
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -1,30 +1,41 @@
+"""
+Saturn-specific override of ``dask.distributed.deploy.SpecCluster``
+
+See https://distributed.dask.org/en/latest/_modules/distributed/deploy/spec.html
+for details on the parent class.
+"""
+
 import os
-import requests
 import json
 import logging
 
-from urllib.parse import urljoin
-from distributed import SpecCluster
-from typing import Any, Dict, List, Optional
 from sys import stdout
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from distributed import SpecCluster
+from tornado.ioloop import PeriodicCallback
+
 
 from .backoff import ExpBackoff
 
 try:
     SATURN_TOKEN = os.environ["SATURN_TOKEN"]
-except KeyError:
+except KeyError as err:
     raise RuntimeError(
         "Required environment variable SATURN_TOKEN not set. "
         "dask-saturn code should only be run on Saturn Cloud infrastructure."
-    )
+    ) from err
 
 try:
     BASE_URL = os.environ["BASE_URL"]
-except KeyError:
+except KeyError as err:
     raise RuntimeError(
         "Required environment variable BASE_URL not set. "
         "dask-saturn code should only be run on Saturn Cloud infrastructure."
-    )
+    ) from err
 
 HEADERS = {"Authorization": f"token {SATURN_TOKEN}"}
 DEFAULT_WAIT_TIMEOUT_SECONDS = 1200
@@ -32,7 +43,7 @@ DEFAULT_WAIT_TIMEOUT_SECONDS = 1200
 logfmt = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 datefmt = "%Y-%m-%d %H:%M:%S"
 
-log = logging.getLogger('dask-saturn')
+log = logging.getLogger("dask-saturn")
 log.setLevel(logging.INFO)
 handler = logging.StreamHandler(stream=stdout)
 handler.setLevel(logging.INFO)
@@ -74,6 +85,7 @@ class SaturnCluster(SpecCluster):
         this parameter to ``True`` if you want to use it in a context manager which
         closes the cluster when it exits.
     """
+
     def __init__(
         self,
         *args,
@@ -104,8 +116,10 @@ class SaturnCluster(SpecCluster):
         self._dashboard_link = info["dashboard_link"]
         self._scheduler_address = info["scheduler_address"]
         self.loop = None
-        self.periodic_callbacks = {}
+        self.periodic_callbacks: Dict[str, PeriodicCallback] = {}
         self.autoclose = autoclose
+
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def reset(
@@ -116,7 +130,6 @@ class SaturnCluster(SpecCluster):
         scheduler_size: Optional[str] = None,
         nprocs: Optional[int] = None,
         nthreads: Optional[int] = None,
-        scheduler_service_wait_timeout: Optional[int] = DEFAULT_WAIT_TIMEOUT_SECONDS,
     ) -> "SaturnCluster":
         """Return a SaturnCluster
 
@@ -142,7 +155,10 @@ class SaturnCluster(SpecCluster):
         return cls(**cluster_config)
 
     @property
-    def status(self) -> str:
+    def status(self) -> Optional[str]:
+        """
+        Status of the cluster
+        """
         if self.cluster_url is None:
             return "closed"
         url = urljoin(self.cluster_url, "status")
@@ -152,24 +168,44 @@ class SaturnCluster(SpecCluster):
         return response.json()["status"]
 
     def _get_pod_status(self) -> Optional[str]:
+        """
+        Status of the KubeCluster pod.
+        """
         response = requests.get(self.cluster_url[:-1], headers=HEADERS)
         if response.ok:
             return response.json()["status"]
+        else:
+            return None
 
     @property
     def _supports_scaling(self) -> bool:
+        """
+        Property required by ``SpecCluster``, which describes
+        whether the cluster can be scaled after it's created.
+        """
         return True
 
     @property
     def scheduler_address(self) -> str:
+        """
+        Address for the Dask schduler.
+        """
         return self._scheduler_address
 
     @property
     def dashboard_link(self) -> str:
+        """
+        Link to the Dask dashboard. This is customized
+        to be inside of a Saturn project.
+        """
         return self._dashboard_link
 
     @property
     def scheduler_info(self) -> Dict[str, Any]:
+        """
+        Information about the scheduler. Raises a
+        ValueError if the scheduler is in a bad state.
+        """
         url = urljoin(self.cluster_url, "scheduler_info")
         response = requests.get(url, headers=HEADERS)
         if not response.ok:
@@ -180,7 +216,7 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
         return response.json()
 
-    def _start(
+    async def _start(
         self,
         n_workers: Optional[int] = None,
         worker_size: Optional[str] = None,
@@ -197,7 +233,7 @@ class SaturnCluster(SpecCluster):
         ``help(SaturnCluster)``.
         """
         url = urljoin(BASE_URL, "api/dask_clusters")
-        self.cluster_url = None
+        self.cluster_url: Optional[str] = None
 
         cluster_config = {
             "n_workers": n_workers,
@@ -209,7 +245,7 @@ class SaturnCluster(SpecCluster):
         }
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
-        logged_warnings = {}
+        logged_warnings: Dict[str, bool] = {}
         while self.cluster_url is None:
             response = requests.post(url, data=json.dumps(cluster_config), headers=HEADERS)
             if not response.ok:
@@ -272,16 +308,16 @@ class SaturnCluster(SpecCluster):
             pc.stop()
 
     @property
-    def asynchronous() -> bool:
+    def asynchronous(self) -> bool:
         return False
 
     def __enter__(self) -> "SaturnCluster":
         assert self.status == "running"
         return self
 
-    def __exit__(self, typ, value, traceback):
+    def __exit__(self, typ, value, traceback) -> None:
         if self.autoclose:
-            return self.close()
+            self.close()
 
 
 def _options() -> Dict[str, Any]:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -216,6 +216,18 @@ class SaturnCluster(SpecCluster):
             raise ValueError(response.reason)
         return response.json()
 
+    @scheduler_info.setter
+    def scheduler_info(self, value) -> None:
+        """
+        Setter to make super-initialization happy when
+        it tries to initialize scheduler_info.
+
+        This value is ignored. Every time you access ``.scheduler_info``,
+        it will get the relevant information by hitting
+        the ``/scheduler_info`` endpoint.
+        """
+        self._scheduler_info = value
+
     # pylint: disable=invalid-overridden-method
     def _start(
         self,

--- a/versioneer.py
+++ b/versioneer.py
@@ -1065,7 +1065,15 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(
         GITS,
-        ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix,],
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
         cwd=root,
     )
     # --long was added in git-1.5.5
@@ -1108,7 +1116,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix,)
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
@@ -1734,7 +1745,11 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError, configparser.NoOptionError,) as e:
+    except (
+        EnvironmentError,
+        configparser.NoSectionError,
+        configparser.NoOptionError,
+    ) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
             print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:


### PR DESCRIPTION
This pull request proposes adding linting to `dask-saturn`, and a GitHub Actions job to run that on every PR. As of this writing, no checks are done on the code when PRs are submitted, and I believe this linting will help catch issues and give us higher confidence in releases.

linters added:

* `black`: auto formatting
* `flake8`: style suggestions and code correctness suggestions
* `pylint`: style suggestions and code correctness suggestions

**issues found by `flake8`**

```text
./dask_saturn/_version.py:254:94: E231 missing whitespace after ','
./dask_saturn/__init__.py:1:1: F401 '.core.describe_sizes' imported but unused
./dask_saturn/__init__.py:1:1: F401 '.core.list_sizes' imported but unused
./dask_saturn/__init__.py:1:1: F401 '.core.SaturnCluster' imported but unused
```

**issues found by `pylint`**

```text
************* Module dask_saturn
dask_saturn/__init__.py:1:0: C0114: Missing module docstring (missing-module-docstring)
************* Module dask_saturn.core
dask_saturn/core.py:1:0: C0114: Missing module docstring (missing-module-docstring)
dask_saturn/core.py:16:4: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
dask_saturn/core.py:24:4: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
dask_saturn/core.py:77:4: W0231: __init__ method from base class 'SpecCluster' is not called (super-init-not-called)
dask_saturn/core.py:78:0: W0613: Unused argument 'args' (unused-argument)
dask_saturn/core.py:78:0: W0613: Unused argument 'kwargs' (unused-argument)
dask_saturn/core.py:119:8: W0613: Unused argument 'scheduler_service_wait_timeout' (unused-argument)
dask_saturn/core.py:145:4: C0116: Missing function or method docstring (missing-function-docstring)
dask_saturn/core.py:154:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
dask_saturn/core.py:172:4: C0116: Missing function or method docstring (missing-function-docstring)
dask_saturn/core.py:183:4: W0236: Method '_start' was expected to be 'async', found it instead as 'non-async' (invalid-overridden-method)
dask_saturn/core.py:275:4: E0211: Method has no argument (no-method-argument)
dask_saturn/core.py:282:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
dask_saturn/core.py:3:0: C0411: standard import "import json" should be placed before "import requests" (wrong-import-order)
dask_saturn/core.py:4:0: C0411: standard import "import logging" should be placed before "import requests" (wrong-import-order)
dask_saturn/core.py:6:0: C0411: standard import "from urllib.parse import urljoin" should be placed before "import requests" (wrong-import-order)
dask_saturn/core.py:8:0: C0411: standard import "from typing import Any, Dict, List, Optional" should be placed before "import requests" (wrong-import-order)
dask_saturn/core.py:9:0: C0411: standard import "from sys import stdout" should be placed before "import requests" (wrong-import-order)
************* Module dask_saturn.backoff
dask_saturn/backoff.py:1:0: C0114: Missing module docstring (missing-module-docstring)
dask_saturn/backoff.py:7:0: C0115: Missing class docstring (missing-class-docstring)
dask_saturn/backoff.py:24:4: C0116: Missing function or method docstring (missing-function-docstring)
dask_saturn/backoff.py:26:12: W0201: Attribute 'start_time' defined outside __init__ (attribute-defined-outside-init)
```

## Changes in this PR

* runs `black` (with `black` 20.8b1, the newest release) to auto-format code
* adds GitHub actions job to run linting on every PR, merge to `main`, and automatically on Monday mornings (U.S. timezones)
* adds `super().__init__(*args, **kwargs)` to `SaturnCluster.__init__()`, so this project keeps up with changes in `distributed.deploy.SpecCluster`
* adds a bunch of docstrings. Some of these are not that informative because I don't understand what the methods do...suggestions welcome!
* changes `SaturnCluster._start()` to async, for consistency with https://distributed.dask.org/en/latest/_modules/distributed/deploy/spec.html
* adds missing `self` to `SaturnCluster.asynchronous`
* removes unused parameter `scheduler_service_wait_timeout` in `SaturnCluster.reset()`
* removes unnecessary `return` in `SaturnCluster.__exit__()`
* adds `from` statements in try-catched exceptions for more accurate tracebacks (see [PEP 3134](https://www.python.org/dev/peps/pep-3134/#explicit-exception-chaining) for details)

## Notes for reviewers

I haven't tested this locally with Saturn yet. Will report back once I do.