### PR TITLE
Don't assert that the cluster is running

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -336,7 +336,6 @@ class SaturnCluster(SpecCluster):
 
             with SaturnCluster() as cluster:
         """
-        assert self.status == "running"
         return self
 
     def __exit__(self, typ, value, traceback) -> None:


### PR DESCRIPTION
Hugo was running into an error when trying to use the context manager with `n_workers` set to > 0. I think in the past we had only really confirmed that this worked with adaptive clusters. So when the workers started being started at the same time as the scheduler it introduces a bit of a race condition. If the scheduler makes it up and is able to return a status before the workers make it up, then the assert will fail.This should fix that.