### PR TITLE
Register plugin after start

### DIFF
--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -4,6 +4,7 @@ imports added so users do not have to think about submodules
 
 from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
+from .plugins import SaturnSetup
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -4,7 +4,7 @@ imports added so users do not have to think about submodules
 
 from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
-from .plugins import SaturnSetup
+from .plugins import SaturnSetup  # noqa: F401
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -131,7 +131,7 @@ class SaturnCluster(SpecCluster):
             self.register_default_plugin()
         except Exception as e:  # pylint: disable=broad-except
             log.warning(
-                f"Registering default plugin failed: {e}. Hint: you might "
+                f"Registering default plugin failed: {e} Hint: you might "
                 "have a different dask-saturn version on your dask cluster."
             )
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -128,7 +128,7 @@ class SaturnCluster(SpecCluster):
         try:
             self.register_default_plugin()
         except Exception as e:
-            log.info("Registering failed: ", e)
+            log.warning(f"Registering failed: {e}")
 
     @classmethod
     def reset(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -130,7 +130,10 @@ class SaturnCluster(SpecCluster):
         try:
             self.register_default_plugin()
         except Exception as e:  # pylint: disable=broad-except
-            log.warning(f"Registering failed: {e}")
+            log.warning(
+                f"Registering default plugin failed: {e}. Hint: you might "
+                "have a different dask-saturn version on your dask cluster."
+            )
 
     @classmethod
     def reset(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -129,7 +129,7 @@ class SaturnCluster(SpecCluster):
         self.autoclose = autoclose
         try:
             self.register_default_plugin()
-        except ImportError as e:
+        except Exception as e:  # pylint: disable=broad-except
             log.warning(f"Registering failed: {e}")
 
     @classmethod

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -10,6 +10,7 @@ class SaturnSetup:
 
     name = "saturn_setup"
 
+    # pylint: disable=no-self-use
     def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -1,0 +1,11 @@
+from distributed.comm import resolve_address
+
+
+class SaturnSetup:
+    name = "saturn_setup"
+
+    def __init__(self, scheduler_address=None):
+        self.scheduler_address = scheduler_address
+
+    def setup(self, worker=None):
+        worker.scheduler.addr = resolve_address(self.scheduler_address)

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -4,8 +4,5 @@ from distributed.comm import resolve_address
 class SaturnSetup:
     name = "saturn_setup"
 
-    def __init__(self, scheduler_address=None):
-        self.scheduler_address = scheduler_address
-
     def setup(self, worker=None):
-        worker.scheduler.addr = resolve_address(self.scheduler_address)
+        worker.scheduler.addr = resolve_address(worker.scheduler.addr)

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -1,8 +1,15 @@
+"""
+Worker plugins to be used with SaturnCluster objects.
+"""
+
 from distributed.comm import resolve_address
 
 
 class SaturnSetup:
+    """WorkerPlugin that finishes setting up SaturnCluster."""
+
     name = "saturn_setup"
 
     def setup(self, worker=None):
+        """This method gets called at worker setup for new and existing workers"""
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)


### PR DESCRIPTION
Ok so new approach, do the work in dask-saturn. To test this out make a new image with pip requirements like:

```
dask[complete]
git+https://github.com/saturncloud/dask-saturn.git@jsignell/register-plugin
```

Create a project with that image, open a notebook and run:
```python
from dask_saturn import SaturnCluster
from dask.distributed import Client

import pandas as pd
import dask.dataframe as dd

cluster = SaturnCluster(n_workers=1)
client = Client(cluster)

df = pd.DataFrame({'df': [1,2,3]})
ddf = dd.from_pandas(df, npartitions=1)
ddf = ddf.persist()

def helper2(fut):
    return fut.compute()
fut2 = client.submit(helper2, ddf)
fut2.result()
```