### PR TITLE
Upload files to all workers, on start, and whenever

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Set up Python 3.7
         if: matrix.task != 'todo-checks'
-        uses: s-weigand/setup-conda@v1.0.3
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           python-version: 3.7
+          auto-activate-base: true
       - name: linting
         if: matrix.task == 'linting'
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
         if: matrix.task == 'linting'
         shell: bash
         run: |
-          pip install --upgrade black flake8 pylint
+          pip install black flake8 pylint
           make lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,12 @@ jobs:
         uses: actions/checkout@v1
       - name: Set up Python 3.7
         if: matrix.task != 'todo-checks'
-        uses: conda-incubator/setup-miniconda@v2
+        uses: s-weigand/setup-conda@v1
         with:
-          miniconda-version: "latest"
           python-version: 3.7
-          auto-activate-base: true
       - name: linting
         if: matrix.task == 'linting'
         shell: bash
         run: |
-          pip install black flake8 pylint
+          pip install --upgrade black flake8 pylint
           make lint

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -4,7 +4,7 @@ imports added so users do not have to think about submodules
 
 from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
-from .plugins import SaturnSetup, UploadFiles, upload_files_to_workers  # noqa: F401
+from .plugins import SaturnSetup, RegisterFiles, sync_files  # noqa: F401
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -4,7 +4,7 @@ imports added so users do not have to think about submodules
 
 from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
-from .plugins import SaturnSetup  # noqa: F401
+from .plugins import SaturnSetup, UploadFiles, upload_files_to_workers  # noqa: F401
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -5,7 +5,8 @@ import os
 import subprocess
 
 from distributed.comm import resolve_address
-from distributed.worker import get_client
+from distributed.worker import get_client, get_worker
+from distributed import worker_client
 
 
 class SaturnSetup:
@@ -21,34 +22,40 @@ class SaturnSetup:
 
 def update_files(client, path):
     tmp_path = None
+    path = os.path.abspath(path)
     if os.path.isdir(path):
+        path += '/'
         tmp_path = "/tmp/data.tar.gz"
-        subprocess.run(f"tar  --exclude .git -cvzf {tmp_path} -C {path} .", shell=True, check=True)
+        subprocess.run(f"tar --exclude .git -cvzf {tmp_path} -C {path} .", shell=True, check=True)
     with open(tmp_path or path, "rb") as f:
         payload = f.read()
     if path in list(client.datasets):
         client.unpublish_dataset(path)
     client.publish_dataset(**{path: payload})
-    client.run(_register_files, client, [path])
+    client.run(register_files, [path])
 
 
-def _register_files(client, paths):
-    for path in paths:
-        if path.endswith("/"):
-            isdir = True
-            tmp_path = "/tmp/data.tar.gz"
-        with open(tmp_path or path, "wb+") as f:
-            f.write(client.get(path))
-        if isdir:
-            subprocess.run(f"mkdir -p {path}", shell=True, check=True)
-            subprocess.run(f"tar -xvzf {tmp_path} -C {path}", shell=True, check=True)
+def register_files(paths=None):
+    """Register all files in the given paths on the workers"""
+    with worker_client(separate_thread=False) as client:
+        if paths is None:
+            paths = client.list_datasets()
+        for path in paths:
+            tmp_path = None
+            if path.endswith("/"):
+                isdir = True
+                tmp_path = "/tmp/data.tar.gz"
+            with open(tmp_path or path, "wb+") as f:
+                f.write(client.get_dataset(path))
+            if isdir:
+                subprocess.run(f"mkdir -p {path}", shell=True, check=True)
+                subprocess.run(f"tar -xvzf {tmp_path} -C {path}", shell=True, check=True)
     return os.listdir()
 
 
-class UploadFile:
+class UploadFiles:
     """WorkerPlugin for uploading files or directories to dask workers."""
 
     def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
-        with get_client(worker) as c:
-            _register_files(c, list(c.datasets))
+        register_files()

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -93,7 +93,7 @@ def sync_files(client, path=None):
         client.unpublish_dataset(p)
 
     client.publish_dataset(**{f"{PREFIX}{path}": payload})
-    client.run_coroutine(register_files_to_worker, paths=[path])
+    client.run(register_files_to_worker, paths=[path])
 
 
 class RegisterFiles:

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -27,7 +27,8 @@ async def _register_files(paths=None):
     with get_client() as client:
         # If paths isn't provided, register all files in datasets that start with prefix
         if paths is None:
-            paths = [p[len(PREFIX) :] for p in await client.list_datasets() if p.startswith(PREFIX)]
+            datasets = await client.list_datasets()
+            paths = [p[len(PREFIX) :] for p in datasets if p.startswith(PREFIX)]
 
         for path in paths:
             # retrieve the filedata from the scheduler
@@ -48,7 +49,11 @@ async def _register_files(paths=None):
 
 
 def upload_files_to_workers(client, path):
-    """Upload files to all workers. Single files or directories are valid."""
+    """Upload files to all workers. Single files or directories are valid.
+
+    If used in conjunction with the ``UploadFiles`` plugin, all files will be uploaded
+    to new workers as they get spun up.
+    """
     # normalize the path
     path = os.path.abspath(path)
 
@@ -74,11 +79,14 @@ def upload_files_to_workers(client, path):
 
 
 class UploadFiles:
-    """WorkerPlugin for uploading files or directories to dask workers."""
+    """WorkerPlugin for uploading files or directories to dask workers.
+
+    Use ``upload_files_to_workers`` to control which paths are tracked.
+    """
 
     name = "upload_files"
 
-    # pylint: disable=no-self-use
+    # pylint: disable=no-self-use,unused-argument
     async def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
         await _register_files()

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -1,8 +1,11 @@
 """
 Worker plugins to be used with SaturnCluster objects.
 """
+import os
+import subprocess
 
 from distributed.comm import resolve_address
+from distributed.worker import get_client
 
 
 class SaturnSetup:
@@ -14,3 +17,38 @@ class SaturnSetup:
     def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)
+
+
+def update_files(client, path):
+    tmp_path = None
+    if os.path.isdir(path):
+        tmp_path = "/tmp/data.tar.gz"
+        subprocess.run(f"tar  --exclude .git -cvzf {tmp_path} -C {path} .", shell=True, check=True)
+    with open(tmp_path or path, "rb") as f:
+        payload = f.read()
+    if path in list(client.datasets):
+        client.unpublish_dataset(path)
+    client.publish_dataset(**{path: payload})
+    client.run(_register_files, client, [path])
+
+
+def _register_files(client, paths):
+    for path in paths:
+        if path.endswith("/"):
+            isdir = True
+            tmp_path = "/tmp/data.tar.gz"
+        with open(tmp_path or path, "wb+") as f:
+            f.write(client.get(path))
+        if isdir:
+            subprocess.run(f"mkdir -p {path}", shell=True, check=True)
+            subprocess.run(f"tar -xvzf {tmp_path} -C {path}", shell=True, check=True)
+    return os.listdir()
+
+
+class UploadFile:
+    """WorkerPlugin for uploading files or directories to dask workers."""
+
+    def setup(self, worker=None):
+        """This method gets called at worker setup for new and existing workers"""
+        with get_client(worker) as c:
+            _register_files(c, list(c.datasets))

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -5,8 +5,10 @@ import os
 import subprocess
 
 from distributed.comm import resolve_address
-from distributed.worker import get_client, get_worker
-from distributed import worker_client
+from distributed.worker import get_client
+
+
+PREFIX = "SATURN__"
 
 
 class SaturnSetup:
@@ -20,42 +22,63 @@ class SaturnSetup:
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)
 
 
-def update_files(client, path):
-    tmp_path = None
-    path = os.path.abspath(path)
-    if os.path.isdir(path):
-        path += '/'
-        tmp_path = "/tmp/data.tar.gz"
-        subprocess.run(f"tar --exclude .git -cvzf {tmp_path} -C {path} .", shell=True, check=True)
-    with open(tmp_path or path, "rb") as f:
-        payload = f.read()
-    if path in list(client.datasets):
-        client.unpublish_dataset(path)
-    client.publish_dataset(**{path: payload})
-    client.run(register_files, [path])
-
-
-def register_files(paths=None):
-    """Register all files in the given paths on the workers"""
-    with worker_client(separate_thread=False) as client:
+async def _register_files(paths=None):
+    """Register all files in the given paths on the current worker"""
+    with get_client() as client:
+        # If paths isn't provided, register all files in datasets that start with prefix
         if paths is None:
-            paths = client.list_datasets()
+            paths = [p[len(PREFIX) :] for p in await client.list_datasets() if p.startswith(PREFIX)]
+
         for path in paths:
-            tmp_path = None
+            # retrieve the filedata from the scheduler
+            payload = await client.get_dataset(f"{PREFIX}{path}")
+
+            # by convention, paths that end with '/' are directories
             if path.endswith("/"):
-                isdir = True
-                tmp_path = "/tmp/data.tar.gz"
-            with open(tmp_path or path, "wb+") as f:
-                f.write(client.get_dataset(path))
-            if isdir:
+                with open("/tmp/data.tar.gz", "wb+") as f:
+                    f.write(payload)
                 subprocess.run(f"mkdir -p {path}", shell=True, check=True)
-                subprocess.run(f"tar -xvzf {tmp_path} -C {path}", shell=True, check=True)
+                subprocess.run(f"tar -xvzf /tmp/data.tar.gz -C {path}", shell=True, check=True)
+            else:
+                basepath = os.path.split(path)[0]
+                subprocess.run(f"mkdir -p {basepath}", shell=True, check=True)
+                with open(path, "wb+") as f:
+                    f.write(payload)
     return os.listdir()
+
+
+def upload_files_to_workers(client, path):
+    """Upload files to all workers. Single files or directories are valid."""
+    # normalize the path
+    path = os.path.abspath(path)
+
+    if os.path.isdir(path):
+        path += "/"
+        subprocess.run(
+            f"tar --exclude .git -cvzf /tmp/data.tar.gz -C {path} .", shell=True, check=True
+        )
+        with open("/tmp/data.tar.gz", "rb") as f:
+            payload = f.read()
+    else:
+        with open(path, "rb") as f:
+            payload = f.read()
+
+    # erase the given file or any file in the directory
+    for p in [p for p in client.list_datasets() if path in p]:
+        client.unpublish_dataset(p)
+
+    client.publish_dataset(**{f"{PREFIX}{path}": payload})
+
+    # update files on any existing workers
+    client.run(_register_files, paths=[path])
 
 
 class UploadFiles:
     """WorkerPlugin for uploading files or directories to dask workers."""
 
-    def setup(self, worker=None):
+    name = "upload_files"
+
+    # pylint: disable=no-self-use
+    async def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
-        register_files()
+        await _register_files()

--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -3,7 +3,9 @@ Worker plugins to be used with SaturnCluster objects.
 """
 import os
 import subprocess
+from typing import List, Optional
 
+from distributed import Client
 from distributed.comm import resolve_address
 from distributed.worker import get_client
 
@@ -22,7 +24,7 @@ class SaturnSetup:
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)
 
 
-async def register_files_to_worker(paths=None):
+async def register_files_to_worker(paths: Optional[List[str]] = None) -> List[str]:
     """Register all files in the given paths on the current worker"""
     with get_client() as client:
         # If paths isn't provided, register all files in datasets that start with prefix
@@ -48,13 +50,13 @@ async def register_files_to_worker(paths=None):
     return os.listdir()
 
 
-def list_files(client):
+def list_files(client: Client) -> List[str]:
     """List all files that are being tracked in the file registry"""
     datasets = client.list_datasets()
     return [p[len(PREFIX) :] for p in datasets if p.startswith(PREFIX)]
 
 
-def clear_files(client):
+def clear_files(client: Client):
     """Clear all files that are being tracked in the file registry.
 
     After this is run, any new worker that is spun up, won't have any files
@@ -65,7 +67,7 @@ def clear_files(client):
         client.unpublish_dataset(path)
 
 
-def sync_files(client, path=None):
+def sync_files(client: Client, path: Optional[str] = None):
     """Upload files to all workers and add to file registry.
 
     :param client: distributed.Client object


### PR DESCRIPTION
This PR creates a new WorkerPlugin and a new top level method for uploading files to the workers.

Create a new image with requirements.txt like:
```
dask[complete]
git+https://github.com/saturncloud/dask-saturn.git@jsignell/datasets
```

Then open a notebook and spin up a cluster

```python
from dask_saturn import SaturnCluster
from distributed import Client

cluster = SaturnCluster()
client = Client(cluster)
```
Create a dir called data with some files in it.  Register `UploadFiles` and use `upload_files_to_workers` to pass the contents of `data` up to the workers.

```python
import os
from dask_saturn.plugins import UploadFiles, upload_files_to_workers

client.register_worker_plugin(UploadFiles())
upload_files_to_workers(client, "data")

client.run(os.listdir, "data")
```

Then scale down the cluster

```python
cluster.scale(0)
```

and scale it back up to prove that the tracked paths are automatically uploaded:

```python
cluster.scale(1)
client.wait_for_workers(1)
client.run(os.listdir, "data")
```