### PR TITLE
Append cwd to python path in worker plugin

### DIFF
--- a/dask_saturn/plugins.py
+++ b/dask_saturn/plugins.py
@@ -2,6 +2,7 @@
 Worker plugins to be used with SaturnCluster objects.
 """
 import os
+import sys
 import subprocess
 from typing import List, Optional
 
@@ -22,6 +23,9 @@ class SaturnSetup:
     def setup(self, worker=None):
         """This method gets called at worker setup for new and existing workers"""
         worker.scheduler.addr = resolve_address(worker.scheduler.addr)
+        cwd = os.getcwd()
+        if cwd not in sys.path:
+            sys.path.append(cwd)
 
 
 async def register_files_to_worker(paths: Optional[List[str]] = None) -> List[str]:


### PR DESCRIPTION
This will resolve Module Not Found issues when the user syncs files to the workers.

To try this out we'll set up a project like

```
/home/jovyan/project/
|---- util/
|   |---- __init__.py
|   |---- hello.py
|
|---- Untitled.ipynb
```

Where hello.py is like:
```python
# util/hello.py
def greet():
    return "Hello"
```

Then within the notebook do:

```python
import dask
from distributed import Client
from dask_saturn import SaturnCluster, RegisterFiles, sync_files

# function from custom module
from util.hello import greet 

cluster = SaturnCluster()
client = Client(dask_cluster)
client.register_worker_plugin(RegisterFiles())
sync_files(client, "util")

# restart the workers so they will see the changes
dask_client.restart()

greet_task = dask.delayed(greet)()
dask.compute(greet_task)
```