### PR TITLE
[CU-5wgufp] external connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ lint:
 	#   * W0212: access to protected member
 	#   * W0221: parameters differ from overridden method
 	#   * W1203: use lazy % formatting
-	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0107,W0212,W0221,W1203 dask_saturn/
+	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0107,W0212,W0221,W1203,wrong-import-order dask_saturn/

--- a/dask_saturn/__init__.py
+++ b/dask_saturn/__init__.py
@@ -5,6 +5,7 @@ imports added so users do not have to think about submodules
 from .core import describe_sizes, list_sizes, SaturnCluster  # noqa: F401
 from ._version import get_versions
 from .plugins import SaturnSetup, RegisterFiles, sync_files  # noqa: F401
+from .external import ExternalConnection  # noqa: F401
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -90,7 +90,7 @@ class SaturnCluster(SpecCluster):
         **kwargs,
     ):
         if external_connection:
-            if type(external_connection) is dict:
+            if isinstance(external_connection, dict):
                 self.external = ExternalConnection(**external_connection)
             else:
                 self.external = external_connection

--- a/dask_saturn/external.py
+++ b/dask_saturn/external.py
@@ -35,7 +35,7 @@ class ExternalConnection:
             raise ValueError("Invalid ExternalConnection: project_id is required")
         self.project_id = project_id
         try:
-            self.settings = Settings(base_url, saturn_token, is_external=True)
+            self.settings = Settings(base_url, saturn_token)
         except Exception as e:
             raise ValueError(f"Invalid ExternalConnection: {e}") from e
 
@@ -48,11 +48,11 @@ class ExternalConnection:
         """
         csr, key = _create_csr(f"Dask Client {dask_cluster_id}")
 
-        url = urljoin(self.settings.BASE_URL, f"/api/dask_clusters/{dask_cluster_id}/csr")
+        url = urljoin(self.settings.url, f"/api/dask_clusters/{dask_cluster_id}/csr")
         resp = requests.post(
             url,
             data=_serialize_csr(csr),
-            headers=self.settings._get_headers(),
+            headers=self.settings.headers,
         )
         if not resp.ok:
             resp.raise_for_status()

--- a/dask_saturn/external.py
+++ b/dask_saturn/external.py
@@ -37,7 +37,7 @@ class ExternalConnection:
         try:
             self.settings = Settings(base_url, saturn_token, is_external=True)
         except Exception as e:
-            raise ValueError(f"Invalid ExternalConnection: {e}")
+            raise ValueError(f"Invalid ExternalConnection: {e}") from e
 
     def _client_tls(
         self, dask_cluster_id: str
@@ -83,7 +83,7 @@ class ExternalConnection:
 
 
 def _create_csr(
-    common_name: str
+    common_name: str,
 ) -> Tuple[x509.CertificateSigningRequest, rsa.RSAPrivateKeyWithSerialization]:
     """Return RSA key and certificate signing request"""
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())

--- a/dask_saturn/external.py
+++ b/dask_saturn/external.py
@@ -48,7 +48,7 @@ class ExternalConnection:
         """
         key, csr = _create_csr(f"Dask Client {dask_cluster_id}")
 
-        url = urljoin(self.settings.BASE_URL, f"/api/dask_clusters/{dask_cluster_id}/external")
+        url = urljoin(self.settings.BASE_URL, f"/api/dask_clusters/{dask_cluster_id}/csr")
         resp = requests.post(
             url,
             data=_serialize_csr(csr),

--- a/dask_saturn/external.py
+++ b/dask_saturn/external.py
@@ -1,0 +1,125 @@
+"""
+Classes and functions for configuring the connection to a Saturn Dask cluster
+from outside of the Saturn installation.
+"""
+
+import requests
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from distributed.security import Security
+from typing import List, Optional
+from urllib.parse import urljoin
+
+from .settings import Settings
+
+
+class ExternalConnection:
+    """
+    Stores settings for connecting to Saturn from an external location, and manages
+    TLS certificates for communicating with the Dask Scheduler.
+    """
+
+    def __init__(
+        self, project_id: str, base_url: Optional[str] = None, saturn_token: Optional[str] = None
+    ):
+        """
+        :param project_id: ID of the project that dask-saturn will connect to
+        :param base_url: Saturn cluster URL. May also be set by the BASE_URL env var.
+        :param saturn_token: User auth token. May also be set by the SATURN_TOKEN env var.
+        """
+
+        self.project_id = project_id
+        self.settings = Settings(base_url, saturn_token)
+
+    def _client_tls(
+        self, dask_cluster_id: str
+    ) -> (rsa.RSAPrivateKey, x509.Certificate, x509.Certificate):
+        """
+        Generate an RSA key and certificate signing request. Send the CSR to Saturn to be signed
+        by the Dask cluster CA, and return the key, cert, and CA.
+        """
+        key, csr = _create_csr(f"Dask Client {dask_cluster_id}")
+
+        url = urljoin(self.settings.BASE_URL, f"/api/dask_clusters/{dask_cluster_id}/external")
+        resp = requests.post(
+            url,
+            data=_serialize_csr(csr),
+            headers=self.settings._get_headers(),
+        )
+        if not resp.ok:
+            raise ValueError(resp.reason)
+
+        cert_chain = _deserialize_cert_chain(resp.content)
+        if len(cert_chain) <= 1:
+            raise ValueError("Invalid certificate chain returned from server")
+        cert = cert_chain[0]
+        ca_cert = cert_chain[1]
+
+        return key, cert, ca_cert
+
+    def security(self, dask_cluster_id: str) -> Security:
+        """
+        Return Dask distributed security for connecting to the given dask cluster's scheduler
+        over a public endpoint.
+        """
+        key, cert, ca_cert = self._client_tls(dask_cluster_id)
+        key_contents = _serialize_key(key).decode()
+        cert_contents = _serialize_cert(cert).decode()
+        ca_cert_contents = _serialize_cert(ca_cert).decode()
+        return Security(
+            tls_client_key=key_contents,
+            tls_client_cert=cert_contents,
+            tls_ca_file=ca_cert_contents,
+            require_encryption=True,
+        )
+
+
+def _create_csr(common_name: str) -> (rsa.RSAPrivateKey, x509.CertificateSigningRequest):
+    """Return RSA key and certificate signing request"""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                ]
+            )
+        )
+        .sign(key, hashes.SHA256(), default_backend())
+    )
+    return key, csr
+
+
+def _serialize_csr(csr: x509.CertificateSigningRequest) -> bytes:
+    """Return the PEM bytes from a certificate signing request"""
+    return csr.public_bytes(serialization.Encoding.PEM)
+
+
+def _serialize_cert(cert: x509.Certificate) -> bytes:
+    """Return the PEM bytes from an X509 certificate"""
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _serialize_key(key: rsa.RSAPrivateKey) -> bytes:
+    """Return the PEM bytes from an RSA private key"""
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _deserialize_cert_chain(data: bytes) -> List[x509.Certificate]:
+    """Return the X509 certificate chain from the given PEM bytes"""
+    pem_start_line = b"-----BEGIN CERTIFICATE-----\n"
+    chain = data.split(pem_start_line)
+    return [
+        x509.load_pem_x509_certificate(pem_start_line + cert_bytes, default_backend())
+        for cert_bytes in chain
+        if cert_bytes
+    ]

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -13,25 +13,19 @@ class Settings:
 
     SATURN_TOKEN: str
     BASE_URL: str
-    is_external: bool
 
     def __init__(
         self,
         base_url: Optional[str] = None,
         saturn_token: Optional[str] = None,
-        is_external: bool = False,
     ):
-        self.is_external = is_external
         if base_url:
             self.BASE_URL = base_url
         else:
             try:
                 self.BASE_URL = os.environ["BASE_URL"]
             except KeyError as err:
-                if self.is_external:
-                    err_msg = "Missing required value base_url."
-                else:
-                    err_msg = "Required environment variable BASE_URL not set."
+                err_msg = "Missing required value Saturn url."
                 raise RuntimeError(err_msg) from err
 
         parsed = urlparse(self.BASE_URL)
@@ -44,12 +38,15 @@ class Settings:
             try:
                 self.SATURN_TOKEN = os.environ["SATURN_TOKEN"]
             except KeyError as err:
-                if self.is_external:
-                    err_msg = "Missing required value saturn_token."
-                else:
-                    err_msg = "Required environment variable SATURN_TOKEN not set."
+                err_msg = "Missing required value Saturn api token."
                 raise RuntimeError(err_msg) from err
 
-    def _get_headers(self, token: Optional[str] = None):
-        """Return Saturn auth headers"""
-        return {"Authorization": f"token {token or self.SATURN_TOKEN}"}
+    @property
+    def url(self):
+        """Saturn url"""
+        return self.BASE_URL
+
+    @property
+    def headers(self):
+        """Saturn auth headers"""
+        return {"Authorization": f"token {self.SATURN_TOKEN}"}

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -1,0 +1,49 @@
+"""
+Settings used for interacting with Saturn
+"""
+
+import os
+
+from typing import Optional
+
+
+class Settings:
+    """Global settings"""
+
+    SATURN_TOKEN: str
+    BASE_URL: str
+    is_external: bool
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        saturn_token: Optional[str] = None,
+        is_external: bool = False,
+    ):
+        if base_url:
+            self.BASE_URL = base_url
+        else:
+            try:
+                self.BASE_URL = os.environ["BASE_URL"]
+            except KeyError as err:
+                if is_external:
+                    err_msg = "Missing required value BASE_URL."
+                else:
+                    err_msg = "Required environment variable BASE_URL not set."
+                raise RuntimeError(err_msg) from err
+
+        if saturn_token:
+            self.SATURN_TOKEN = saturn_token
+        else:
+            try:
+                self.SATURN_TOKEN = os.environ["SATURN_TOKEN"]
+            except KeyError as err:
+                if is_external:
+                    err_msg = "Missing required value SATURN_TOKEN."
+                else:
+                    err_msg = "Required environment variable SATURN_TOKEN not set."
+                raise RuntimeError(err_msg) from err
+
+    def _get_headers(self, token: Optional[str] = None):
+        """Return Saturn auth headers"""
+        return {"Authorization": f"token {token or self.SATURN_TOKEN}"}

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -5,6 +5,7 @@ Settings used for interacting with Saturn
 import os
 
 from typing import Optional
+from urllib.parse import urlparse
 
 
 class Settings:
@@ -20,17 +21,22 @@ class Settings:
         saturn_token: Optional[str] = None,
         is_external: bool = False,
     ):
+        self.is_external = is_external
         if base_url:
             self.BASE_URL = base_url
         else:
             try:
                 self.BASE_URL = os.environ["BASE_URL"]
             except KeyError as err:
-                if is_external:
-                    err_msg = "Missing required value BASE_URL."
+                if self.is_external:
+                    err_msg = "Missing required value base_url."
                 else:
                     err_msg = "Required environment variable BASE_URL not set."
                 raise RuntimeError(err_msg) from err
+
+        parsed = urlparse(self.BASE_URL)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f'"{self.BASE_URL}" is not a valid URL')
 
         if saturn_token:
             self.SATURN_TOKEN = saturn_token
@@ -38,8 +44,8 @@ class Settings:
             try:
                 self.SATURN_TOKEN = os.environ["SATURN_TOKEN"]
             except KeyError as err:
-                if is_external:
-                    err_msg = "Missing required value SATURN_TOKEN."
+                if self.is_external:
+                    err_msg = "Missing required value saturn_token."
                 else:
                     err_msg = "Required environment variable SATURN_TOKEN not set."
                 raise RuntimeError(err_msg) from err


### PR DESCRIPTION
- Move settings into a class in its own file
- Add ExternalConnection class for configuring access to a Saturn dask cluster from outside of the Saturn installation
  - Settings for project_id, base_url, saturn_token
  - Generates client TLS key and CSR, requests signed certificate from Atlas
  - Configures dask Security object for the SaturnCluster
- Add extra parameters on Atlas requests to enable the TCP+TLS proxy connection