### PR TITLE
Remove logger config

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,7 +9,6 @@ import os
 import json
 import logging
 
-from sys import stdout
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -26,15 +25,7 @@ from .plugins import SaturnSetup
 
 DEFAULT_WAIT_TIMEOUT_SECONDS = 1200
 
-logfmt = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
-datefmt = "%Y-%m-%d %H:%M:%S"
-
 log = logging.getLogger("dask-saturn")
-log.setLevel(logging.INFO)
-handler = logging.StreamHandler(stream=stdout)
-handler.setLevel(logging.INFO)
-handler.setFormatter(logging.Formatter(logfmt, datefmt))
-log.addHandler(handler)
 
 
 def _get_base_url():

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -26,6 +26,8 @@ from .plugins import SaturnSetup
 DEFAULT_WAIT_TIMEOUT_SECONDS = 1200
 
 log = logging.getLogger("dask-saturn")
+if log.level == logging.NOTSET:
+    log.setLevel(logging.INFO)
 
 
 def _get_base_url():


### PR DESCRIPTION
Stemming from a discussion on `saturn-client`: https://github.com/saturncloud/saturn-client/pull/1#discussion_r545154513

This PR proposes removal of `logging` configuration. If used inside someone's application, this configuration will likely result in different log formats being used than other parts of the application, which can be rather painful to remove/coerce (like we do for `tornado`, `boto3`, and `alembic` in some of our codebases) if uniformity is required for log processing (as it is for some of our applications).

The consequences of this PR are small, but do exist - by default, `logging` only logs `WARNING` and above. We've been setting it to `INFO`- output would decrease unless configured.