### PR TITLE
Simplify conda-update Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: conda-update
 conda-update:
-	envsubst < environment.yaml > /tmp/environment.yaml
-	conda env update -n dask-saturn --file /tmp/environment.yaml
+	conda env update -n dask-saturn --file environment.yaml
 
 .PHONY: format
 format:


### PR DESCRIPTION
The `envsubst` usage was needed when our repos depended on specific versions of `sutils` - now that this is no longer the case, our `conda-update` targets can be straightforward.