### PR TITLE
centralize CI configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
       - id: black
         language_version: python3.7
-        args: ["--line-length", "100"]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,10 @@ conda-update:
 
 .PHONY: format
 format:
-	black --line-length 100 .
+	black .
 
 .PHONY: lint
 lint:
-	flake8 --count --max-line-length 100 --exclude versioneer.py .
-	black --check --diff --line-length 100 .
-	# pylint disables:
-	#   * C0301: line too long
-	#   * C0103: snake-case naming
-	#   * C0330: wrong hanging indent before block
-	#   * E0401: unable to import
-	#   * R0903: too few public methods
-	#   * R0913: too many arguments
-	#   * R0914: too many local variables
-	#   * R1705: Unnecessary "else" after "return"
-	#   * R1720: Unnecessary "elif" after "return"
-	#   * W0107: unnecessary "pass" statement
-	#   * W0212: access to protected member
-	#   * W0221: parameters differ from overridden method
-	#   * W1203: use lazy % formatting
-	pylint --disable=C0103,C0301,C0330,E0401,R0903,R0913,R0914,R1705,R1720,W0107,W0212,W0221,W1203,wrong-import-order dask_saturn/
+	flake8 --count --exclude versioneer.py .
+	black --check --diff .
+	pylint dask_saturn/

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ format:
 
 .PHONY: lint
 lint:
-	flake8 --count --exclude versioneer.py .
+	flake8 --count .
 	black --check --diff .
 	pylint dask_saturn/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,30 @@ ignore =
 
 max-line-length = 100
 
+[pylint.MESSAGES_CONTROL]
+
+# This controls the checks that pylint ignores.
+#
+# If you add to this list, please keep it in
+# alphabetical order.
+#
+# to list all possibilities, run:
+#
+#     pylint --list-msg
+#
+disable=
+    arguments-differ,
+    import-error,
+    invalid-name,
+    logging-fstring-interpolation,
+    no-else-raise,
+    no-else-return,
+    protected-access,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-locals,
+    wrong-import-order
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Moves configuration for `black`, `flake8`, and `pylint` out of `Makefile` and into root-level config files.

## How does this PR improve `dask-saturn`?

This makes the behavior of these linters consistent regardless of how you run them. Now the behavior from `make lint` will be the same as, say, `pylint prefect_saturn/`.

I chose to put as many as I could in `setup.cg` instead of introducing individual files like `.flake8` to minimize the number of files you have to think about.