### PR TITLE
Improve error messages and check sizes before submitting

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -68,9 +68,10 @@ class SaturnCluster(SpecCluster):
         outside of the Saturn installation.
     """
 
+    # pylint: disable=unused-argument,super-init-not-called,too-many-instance-attributes
+
     _sizes = None
 
-    # pylint: disable=unused-argument,super-init-not-called,too-many-instance-attributes
     def __init__(
         self,
         *args,

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -169,7 +169,7 @@ class SaturnCluster(SpecCluster):
         response = requests.post(url, data=json.dumps(cluster_config), headers=settings.headers)
         try:
             response.raise_for_status()
-        except HTTPError as err:
+        except HTTPError:
             raise ValueError(response.json()["message"])
         return cls(**cluster_config, external_connection=external_connection)
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import requests
-from requests.exceptions import HTTPError
 
 from distributed import Client, SpecCluster
 from distributed.security import Security
@@ -167,9 +166,7 @@ class SaturnCluster(SpecCluster):
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
         response = requests.post(url, data=json.dumps(cluster_config), headers=settings.headers)
-        try:
-            response.raise_for_status()
-        except HTTPError:
+        if not response.ok:
             raise ValueError(response.json()["message"])
         return cls(**cluster_config, external_connection=external_connection)
 
@@ -281,9 +278,7 @@ class SaturnCluster(SpecCluster):
                 data=json.dumps(cluster_config),
                 headers=self.settings.headers,
             )
-            try:
-                response.raise_for_status()
-            except HTTPError:
+            if not response.ok:
                 raise ValueError(response.json()["message"])
             data = response.json()
             warnings = data.get("warnings")
@@ -320,9 +315,7 @@ class SaturnCluster(SpecCluster):
         if self.external:
             url += "?is_external=true"
         response = requests.get(url, headers=self.settings.headers)
-        try:
-            response.raise_for_status()
-        except HTTPError:
+        if not response.ok:
             raise ValueError(response.json()["message"])
         return response.json()
 
@@ -334,9 +327,7 @@ class SaturnCluster(SpecCluster):
         """
         url = urljoin(self.cluster_url, "scale")
         response = requests.post(url, json.dumps({"n": n}), headers=self.settings.headers)
-        try:
-            response.raise_for_status()
-        except HTTPError:
+        if not response.ok:
             raise ValueError(response.json()["message"])
 
     def adapt(self, minimum: int, maximum: int) -> None:
@@ -347,9 +338,7 @@ class SaturnCluster(SpecCluster):
             json.dumps({"minimum": minimum, "maximum": maximum}),
             headers=self.settings.headers,
         )
-        try:
-            response.raise_for_status()
-        except HTTPError:
+        if not response.ok:
             raise ValueError(response.json()["message"])
 
     def close(self) -> None:
@@ -358,9 +347,7 @@ class SaturnCluster(SpecCluster):
         """
         url = urljoin(self.cluster_url, "close")
         response = requests.post(url, headers=self.settings.headers)
-        try:
-            response.raise_for_status()
-        except HTTPError:
+        if not response.ok:
             raise ValueError(response.json()["message"])
         for pc in self.periodic_callbacks.values():
             pc.stop()
@@ -434,9 +421,7 @@ def _options(external_connection: Optional[ExternalConnection] = None) -> Dict[s
         settings = external_connection.settings
     url = urljoin(settings.url, "api/dask_clusters/info")
     response = requests.get(url, headers=settings.headers)
-    try:
-        response.raise_for_status()
-    except HTTPError:
+    if not response.ok:
         raise ValueError(response.json()["message"])
     return response.json()["server_options"]
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -169,7 +169,7 @@ class SaturnCluster(SpecCluster):
         try:
             response.raise_for_status()
         except HTTPError as err:
-            raise HTTPError(response.status_code, response.json()["message"]) from err
+            raise ValueError(response.json()["message"])
         return cls(**cluster_config, external_connection=external_connection)
 
     @property
@@ -282,8 +282,8 @@ class SaturnCluster(SpecCluster):
             )
             try:
                 response.raise_for_status()
-            except HTTPError as err:
-                raise HTTPError(response.status_code, response.json()["message"]) from err
+            except HTTPError:
+                raise ValueError(response.json()["message"])
             data = response.json()
             warnings = data.get("warnings")
             if warnings is not None:
@@ -321,8 +321,8 @@ class SaturnCluster(SpecCluster):
         response = requests.get(url, headers=self.settings.headers)
         try:
             response.raise_for_status()
-        except HTTPError as err:
-            raise HTTPError(response.status_code, response.json()["message"]) from err
+        except HTTPError:
+            raise ValueError(response.json()["message"])
         return response.json()
 
     def scale(self, n: int) -> None:
@@ -335,8 +335,8 @@ class SaturnCluster(SpecCluster):
         response = requests.post(url, json.dumps({"n": n}), headers=self.settings.headers)
         try:
             response.raise_for_status()
-        except HTTPError as err:
-            raise HTTPError(response.status_code, response.json()["message"]) from err
+        except HTTPError:
+            raise ValueError(response.json()["message"])
 
     def adapt(self, minimum: int, maximum: int) -> None:
         """Adapt cluster to have between ``minimum`` and ``maximum`` workers"""
@@ -348,8 +348,8 @@ class SaturnCluster(SpecCluster):
         )
         try:
             response.raise_for_status()
-        except HTTPError as err:
-            raise HTTPError(response.status_code, response.json()["message"]) from err
+        except HTTPError:
+            raise ValueError(response.json()["message"])
 
     def close(self) -> None:
         """
@@ -359,8 +359,8 @@ class SaturnCluster(SpecCluster):
         response = requests.post(url, headers=self.settings.headers)
         try:
             response.raise_for_status()
-        except HTTPError as err:
-            raise HTTPError(response.status_code, response.json()["message"]) from err
+        except HTTPError:
+            raise ValueError(response.json()["message"])
         for pc in self.periodic_callbacks.values():
             pc.stop()
 
@@ -435,8 +435,8 @@ def _options(external_connection: Optional[ExternalConnection] = None) -> Dict[s
     response = requests.get(url, headers=settings.headers)
     try:
         response.raise_for_status()
-    except HTTPError as err:
-        raise HTTPError(response.status_code, response.json()["message"]) from err
+    except HTTPError:
+        raise ValueError(response.json()["message"])
     return response.json()["server_options"]
 
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -276,7 +276,9 @@ class SaturnCluster(SpecCluster):
         logged_warnings: Dict[str, bool] = {}
         while self.cluster_url is None:
             response = requests.post(
-                url + url_query, data=json.dumps(cluster_config), headers=self.settings.headers,
+                url + url_query,
+                data=json.dumps(cluster_config),
+                headers=self.settings.headers,
             )
             try:
                 response.raise_for_status()
@@ -401,7 +403,9 @@ class SaturnCluster(SpecCluster):
 
     # pylint: disable=access-member-before-definition
     def _validate_sizes(
-        self, worker_size: Optional[str] = None, scheduler_size: Optional[str] = None,
+        self,
+        worker_size: Optional[str] = None,
+        scheduler_size: Optional[str] = None,
     ):
         """Validate the options provided"""
         if self._sizes is None:


### PR DESCRIPTION
With a start script like: `pip install git+https://github.com/saturncloud/dask-saturn@jsignell/better-errors`

## Generic backend error propagation
```python
from dask_saturn import SaturnCluster

SaturnCluster(n_workers="cat")
```

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-30ca30076ae4> in <module>
      2 from dask_saturn import SaturnCluster
      3 
----> 4 cluster = SaturnCluster(n_workers="foo")
      5 client = Client(cluster)
      6 cluster

/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py in __init__(self, n_workers, cluster_url, worker_size, worker_is_spot, scheduler_size, nprocs, nthreads, scheduler_service_wait_timeout, autoclose, external_connection, *args, **kwargs)
    105                 nprocs=nprocs,
    106                 nthreads=nthreads,
--> 107                 scheduler_service_wait_timeout=scheduler_service_wait_timeout,
    108             )
    109         else:

/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py in _start(self, n_workers, worker_size, worker_is_spot, scheduler_size, nprocs, nthreads, scheduler_service_wait_timeout)
    280             )
    281             if not response.ok:
--> 282                 raise ValueError(response.json()["message"])
    283             data = response.json()
    284             warnings = data.get("warnings")

ValueError: Validation errors: {'n_workers': ['Not a valid integer.']}
```

## Client-side validation
```python
from dask_saturn import SaturnCluster

SaturnCluster(worker_size="foo")
```

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-95914b8c3d8f> in <module>
      2 from dask_saturn import SaturnCluster
      3 
----> 4 cluster = SaturnCluster(worker_size="foo")
      5 client = Client(cluster)
      6 cluster

/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py in __init__(self, n_workers, cluster_url, worker_size, worker_is_spot, scheduler_size, nprocs, nthreads, scheduler_service_wait_timeout, autoclose, external_connection, *args, **kwargs)
    105                 nprocs=nprocs,
    106                 nthreads=nthreads,
--> 107                 scheduler_service_wait_timeout=scheduler_service_wait_timeout,
    108             )
    109         else:

/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py in _start(self, n_workers, worker_size, worker_is_spot, scheduler_size, nprocs, nthreads, scheduler_service_wait_timeout)
    258         self.cluster_url: Optional[str] = None
    259 
--> 260         self._validate_sizes(worker_size, scheduler_size)
    261 
    262         cluster_config = {

/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py in _validate_sizes(self, worker_size, scheduler_size)
    420                 )
    421         if len(errors) > 0:
--> 422             raise ValueError(" ".join(errors))
    423 
    424 

ValueError: Proposed worker_size: foo is not a valid option. Options are: ['micro', 'medium', 'microgpu', 'megagpu']. Proposed scheduler_size: None is not a valid option. Options are: ['micro', 'medium', 'microgpu', 'megagpu'].
```