### PR TITLE
allow setting worker_size without also setting scheduler_size

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -411,6 +411,7 @@ class SaturnCluster(SpecCluster):
                     f"Proposed worker_size: {worker_size} is not a valid option. "
                     f"Options are: {self._sizes}."
                 )
+        if scheduler_size is not None:
             if scheduler_size not in self._sizes:
                 errors.append(
                     f"Proposed scheduler_size: {scheduler_size} is not a valid option. "


### PR DESCRIPTION
Running https://github.com/saturncloud/examples/blob/main/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb using `dask-saturn` 0.2.2, I ran into this error:

> Unexpected error: ValueError("Proposed scheduler_size: None is not a valid option. Options are: ['medium', 'large', 'xlarge', '2xlarge', '4xlarge', '8xlarge', '12xlarge', '16xlarge', 'g4dnxlarge', 'g4dn4xlarge', 'g4dn8xlarge', 'p32xlarge', 'p38xlarge', 'p316xlarge'].")

I think this is because the code in that notebook sets `worker_size` but not `scheduler_size`.

`None` should be a valid value for `scheduler_size`, since Saturn's back-end interprets that as "use the default size". This PR proposes fixing that check so that people using `SaturnCluster(worker_size="something")` don't run into this issue.