### PR TITLE
[DEV-1757] Only output one line for success of worker plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: stable
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3.7

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -280,9 +280,7 @@ class SaturnCluster(SpecCluster):
         logged_warnings: Dict[str, bool] = {}
         while self.cluster_url is None:
             response = requests.post(
-                url + url_query,
-                data=json.dumps(cluster_config),
-                headers=self.settings.headers,
+                url + url_query, data=json.dumps(cluster_config), headers=self.settings.headers,
             )
             if not response.ok:
                 raise ValueError(response.json()["message"])
@@ -312,9 +310,18 @@ class SaturnCluster(SpecCluster):
     def register_default_plugin(self):
         """Register the default SaturnSetup plugin to all workers."""
         log.info("Registering default plugins")
+        outputs = {}
         with Client(self) as client:
             output = client.register_worker_plugin(SaturnSetup())
-            log.info(output)
+            outputs.update(output)
+        if "ok" in outputs.values():
+            log.info("Success!")
+        elif "repeat" in output.values():
+            log.info("Success!")
+        elif len(output) == 0:
+            log.warning("No workers started up.")
+        else:
+            log.warning("Registering default plugins failed. Please check logs for more info.")
 
     def _get_info(self) -> Dict[str, Any]:
         url = urljoin(self.cluster_url, "info")
@@ -397,9 +404,7 @@ class SaturnCluster(SpecCluster):
 
     # pylint: disable=access-member-before-definition
     def _validate_sizes(
-        self,
-        worker_size: Optional[str] = None,
-        scheduler_size: Optional[str] = None,
+        self, worker_size: Optional[str] = None, scheduler_size: Optional[str] = None,
     ):
         """Validate the options provided"""
         if self._sizes is None:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -280,7 +280,9 @@ class SaturnCluster(SpecCluster):
         logged_warnings: Dict[str, bool] = {}
         while self.cluster_url is None:
             response = requests.post(
-                url + url_query, data=json.dumps(cluster_config), headers=self.settings.headers,
+                url + url_query,
+                data=json.dumps(cluster_config),
+                headers=self.settings.headers,
             )
             if not response.ok:
                 raise ValueError(response.json()["message"])
@@ -405,7 +407,9 @@ class SaturnCluster(SpecCluster):
 
     # pylint: disable=access-member-before-definition
     def _validate_sizes(
-        self, worker_size: Optional[str] = None, scheduler_size: Optional[str] = None,
+        self,
+        worker_size: Optional[str] = None,
+        scheduler_size: Optional[str] = None,
     ):
         """Validate the options provided"""
         if self._sizes is None:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -314,11 +314,12 @@ class SaturnCluster(SpecCluster):
         with Client(self) as client:
             output = client.register_worker_plugin(SaturnSetup())
             outputs.update(output)
-        if "ok" in outputs.values():
+        output_statuses = [v["status"] for v in outputs.values()]
+        if "OK" in output_statuses:
             log.info("Success!")
-        elif "repeat" in output.values():
+        elif "repeat" in output_statuses:
             log.info("Success!")
-        elif len(output) == 0:
+        elif len(output_statuses) == 0:
             log.warning("No workers started up.")
         else:
             log.warning("Registering default plugins failed. Please check logs for more info.")


### PR DESCRIPTION
This PR collapses the output from the `SaturnSetup` plugin so that it's less overwhelming.

![image](https://user-images.githubusercontent.com/4806877/108731656-c45ce380-74fa-11eb-85ea-30cd1f025b9e.png)
