### PR TITLE
One dask cluster per prefect cloud flow run

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ option. Similarly, you can set the `scheduler_size`, `worker_size`, and `worker_
 > Note: If the cluster is already running then you can't change the settings.
 > Attempting to do so will raise a warning.
 
-Use the `autoclose` option to set up a cluster that is tied to the client
+Use the `shudown_on_close` option to set up a cluster that is tied to the client
 kernel. This functions like a regular dask `LocalCluster`, when your jupyter
 kernel dies or is restarted, the dask cluster will close.
 

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -66,8 +66,9 @@ class SaturnCluster(SpecCluster):
         when its calling process is destroyed. Set this parameter to ``True`` if you want
         your cluster to shutdown when the work is done.
         By default, this is ``False`` if the cluster is attached to a Jupyter server,
-        deployment, or job and ``True`` if the cluster is attached to a Prefect Cloud flow run.
-        ``autoclose`` is accepted as an alias for now, but will be removed in the future.
+        deployment, or job. If the cluster is attached to a Prefect Cloud flow run, this option
+        is always set to ``True``.
+        Note: ``autoclose`` is accepted as an alias for now, but will be removed in the future.
     """
 
     # pylint: disable=unused-argument,super-init-not-called,too-many-instance-attributes
@@ -86,7 +87,7 @@ class SaturnCluster(SpecCluster):
         nprocs: Optional[int] = None,
         nthreads: Optional[int] = None,
         scheduler_service_wait_timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
-        shutdown_on_close: Optional[bool] = None,
+        shutdown_on_close: bool = False,
         **kwargs,
     ):
         if "external_connection" in kwargs:
@@ -106,9 +107,9 @@ class SaturnCluster(SpecCluster):
 
         self.settings = Settings()
 
-        if shutdown_on_close is None:
+        if self.settings.is_prefect:
             # defaults to True if related to prefect, else defaults to False
-            shutdown_on_close = self.settings.is_prefect
+            shutdown_on_close = True
 
         if cluster_url is None:
             self._start(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -275,7 +275,7 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            "resource_id": os.environ.get("SATURN_ID"),
+            **os.environ,
         }
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -276,19 +276,15 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            "prefectcloudflowrun_id": str(self.settings.SATURN_VERSION),
         }
 
         if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):
-            cluster_config["prefectcloudflowrun_id"]: os.environ.get(
+            cluster_config["prefectcloudflowrun_id"] = os.environ.get(
                 "PREFECT__CONTEXT__FLOW_RUN_ID"
             )
-        else:
-            cluster_config["prefectcloudflowrun_id"] = str(self.settings.SATURN_VERSION)
 
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
-
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -281,7 +281,9 @@ class SaturnCluster(SpecCluster):
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
         if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):
-            cluster_config["prefectcloudflowrun_id"]: os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID")
+            cluster_config["prefectcloudflowrun_id"]: os.environ.get(
+                "PREFECT__CONTEXT__FLOW_RUN_ID"
+            )
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -284,6 +284,8 @@ class SaturnCluster(SpecCluster):
             cluster_config["prefectcloudflowrun_id"]: os.environ.get(
                 "PREFECT__CONTEXT__FLOW_RUN_ID"
             )
+        else:
+            cluster_config["prefectcloudflowrun_id"] = str(self.settings.SATURN_VERSION)
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -276,7 +276,7 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            "prefectcloudflowrun_id": self.settings.SATURN_VERSION,
+            "prefectcloudflowrun_id": str(self.settings.SATURN_VERSION),
         }
 
         if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,6 +9,7 @@ import os
 import json
 import logging
 
+from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -275,10 +276,14 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            "prefectcloudflowrun_id": os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID"),
         }
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
+
+        if self.settings.SATURN_VERSION >= LooseVersion("v2021.08.16"):
+            cluster_config["prefectcloudflowrun_id"]: os.environ.get(
+                "PREFECT__CONTEXT__FLOW_RUN_ID"
+            )
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -7,6 +7,7 @@ for details on the parent class.
 import os
 import json
 import logging
+import weakref
 
 from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
@@ -68,6 +69,7 @@ class SaturnCluster(SpecCluster):
     # pylint: disable=unused-argument,super-init-not-called,too-many-instance-attributes
 
     _sizes = None
+    _instances = weakref.WeakSet()
 
     def __init__(
         self,
@@ -94,6 +96,7 @@ class SaturnCluster(SpecCluster):
             shutdown_on_close = kwargs.pop("autoclose")
 
         self.settings = Settings()
+        self._instances.add(self)
 
         # if dask-cluster is related to a prefect, shutdown_on_close is always true.
         if self.settings.is_prefect:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -96,12 +96,10 @@ class SaturnCluster(SpecCluster):
             shutdown_on_close = kwargs.pop("autoclose")
 
         self.settings = Settings()
-        self._instances.add(self)
 
         # if dask-cluster is related to a prefect, shutdown_on_close is always true.
         if self.settings.is_prefect:
             shutdown_on_close = True
-            self._instances.add(self)
 
         if cluster_url is None:
             self._start(
@@ -118,12 +116,15 @@ class SaturnCluster(SpecCluster):
             self.dask_cluster_id = self.cluster_url.rstrip("/").split("/")[-1]
 
         info = self._get_info()
+        self._name = self.dask_cluster_id
         self._dashboard_link = info["dashboard_link"]
         self._scheduler_address = info["scheduler_address"]
         self.loop = None
         self.periodic_callbacks: Dict[str, PeriodicCallback] = {}
         self.shutdown_on_close = shutdown_on_close
         self._adaptive = None
+        self._instances.add(self)
+
         if self.settings.is_external:
             self.security = _security(self.settings, self.dask_cluster_id)
         else:

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,7 +9,6 @@ import os
 import json
 import logging
 
-from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -280,7 +279,7 @@ class SaturnCluster(SpecCluster):
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
-        if self.settings.SATURN_VERSION >= LooseVersion("v2021.08.16"):
+        if self.settings.SATURN_VERSION >= "v2021.08.16":
             cluster_config["prefectcloudflowrun_id"]: os.environ.get(
                 "PREFECT__CONTEXT__FLOW_RUN_ID"
             )

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -276,6 +276,7 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
+            "prefectcloudflowrun_id": os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID"),
         }
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -5,6 +5,7 @@ See https://distributed.dask.org/en/latest/_modules/distributed/deploy/spec.html
 for details on the parent class.
 """
 
+import os
 import json
 import logging
 
@@ -274,6 +275,7 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
+            "resource_id": os.environ.get("SATURN_ID"),
         }
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -311,12 +311,10 @@ class SaturnCluster(SpecCluster):
             if not response.ok:
                 raise ValueError(response.json()["message"])
             data = response.json()
-            warnings = data.get("warnings")
-            if warnings is not None:
-                for warning in warnings:
-                    if not logged_warnings.get(warning):
-                        logged_warnings[warning] = True
-                        log.warning(warning)
+            for warning in data.get("warnings", []):
+                if not logged_warnings.get(warning):
+                    logged_warnings[warning] = True
+                    log.warning(warning)
             if data["status"] == "error":
                 raise ValueError(" ".join(data["errors"]))
             elif data["status"] == "ready":

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,6 +9,7 @@ import os
 import json
 import logging
 
+from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -279,10 +280,8 @@ class SaturnCluster(SpecCluster):
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
-        if self.settings.SATURN_VERSION >= "v2021.08.16":
-            cluster_config["prefectcloudflowrun_id"]: os.environ.get(
-                "PREFECT__CONTEXT__FLOW_RUN_ID"
-            )
+        if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):
+            cluster_config["prefectcloudflowrun_id"]: os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID")
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -275,7 +275,7 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            **os.environ,
+            "prefectcloudflowrun_id": os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID"),
         }
         # only send kwargs that are explicitly set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -93,6 +93,10 @@ class SaturnCluster(SpecCluster):
 
         self.settings = Settings()
 
+        # if dask-cluster is related to a prefect, autoclose is always true.
+        if self.settings.is_prefect:
+            autoclose = True
+
         if cluster_url is None:
             self._start(
                 n_workers=n_workers,

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -276,10 +276,8 @@ class SaturnCluster(SpecCluster):
             "scheduler_size": scheduler_size,
             "nprocs": nprocs,
             "nthreads": nthreads,
-            "prefectcloudflowrun_id": os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID"),
+            "prefectcloudflowrun_id": self.settings.SATURN_VERSION,
         }
-        # only send kwargs that are explicitly set by user
-        cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
         if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):
             cluster_config["prefectcloudflowrun_id"]: os.environ.get(
@@ -287,6 +285,10 @@ class SaturnCluster(SpecCluster):
             )
         else:
             cluster_config["prefectcloudflowrun_id"] = str(self.settings.SATURN_VERSION)
+
+        # only send kwargs that are explicitly set by user
+        cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
+
 
         expBackoff = ExpBackoff(wait_timeout=scheduler_service_wait_timeout)
         logged_warnings: Dict[str, bool] = {}

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -49,7 +49,7 @@ class Settings:
 
     @property
     def is_prefect(self) -> bool:
-        return os.environ.get("SATURN_RESOURCE_TYPE", "SingleUserServer") == "PrefectCloudFlowRun"
+        return os.environ.get("SATURN_RESOURCE_TYPE", "SingleUserServer").startswith("Prefect")
 
     @property
     def url(self):
@@ -59,12 +59,7 @@ class Settings:
     @property
     def headers(self):
         """Saturn auth headers"""
-        if not self.is_prefect or os.environ.get("SATURN_ID") is None:
-            extra = {}
-        else:
-            extra = {"X-Prefect-Cloud-Flow-Run-ID": os.environ.get("SATURN_ID")}
         return {
             "Authorization": f"token {self.SATURN_TOKEN}",
             "X-Dask-Saturn-Version": __version__,
-            **extra,
         }

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -15,8 +15,9 @@ class Settings:
 
     SATURN_TOKEN: str
     SATURN_BASE_URL: str
+    SATURN_VERSION: str
 
-    def __init__(self):
+    async def __init__(self):
         try:
             self.SATURN_BASE_URL = os.environ["SATURN_BASE_URL"]
         except KeyError as err:
@@ -41,6 +42,9 @@ class Settings:
         except KeyError as err:
             err_msg = "Missing required environment variable SATURN_TOKEN."
             raise RuntimeError(err_msg) from err
+
+        # get the SATURN_VERSION if included, default to the one before field was added.
+        self.SATURN_VERSION = os.environ.get("SATURN_VERSION", "v2021.07.19-12")
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
-__version__ = "0.4.2"  # get_versions()["version"]
+__version__ = get_versions()["version"]
 
 
 class Settings:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -4,7 +4,6 @@ Settings used for interacting with Saturn
 
 import os
 
-from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
@@ -16,7 +15,7 @@ class Settings:
 
     SATURN_TOKEN: str
     SATURN_BASE_URL: str
-    SATURN_VERSION: LooseVersion
+    SATURN_VERSION: str
 
     def __init__(self):
         try:
@@ -45,7 +44,7 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "v2021.07.19"))
+        self.SATURN_VERSION = os.environ.get("SATURN_VERSION", "v2021.07.19")
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -4,10 +4,11 @@ Settings used for interacting with Saturn
 
 import os
 
+from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
-__version__ = "0.4.0" # get_versions()["version"]
+__version__ = "0.4.0"  # get_versions()["version"]
 
 
 class Settings:
@@ -15,7 +16,7 @@ class Settings:
 
     SATURN_TOKEN: str
     SATURN_BASE_URL: str
-    SATURN_VERSION: str
+    SATURN_VERSION: LooseVersion
 
     def __init__(self):
         try:
@@ -44,7 +45,7 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = os.environ.get("SATURN_VERSION", "v2021.07.19")
+        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "2021.07.19"))
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
-__version__ = "0.4.0"  # get_versions()["version"]
+__version__ = "0.4.1"  # get_versions()["version"]
 
 
 class Settings:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
-__version__ = "0.4.1"  # get_versions()["version"]
+__version__ = "0.4.2"  # get_versions()["version"]
 
 
 class Settings:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -16,7 +16,7 @@ class Settings:
 
     SATURN_TOKEN: str
     SATURN_BASE_URL: str
-    SATURN_VERSION: str
+    SATURN_VERSION: LooseVersion
 
     def __init__(self):
         try:
@@ -45,7 +45,7 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "v2021.07.19-12"))
+        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "v2021.07.19"))
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -17,7 +17,7 @@ class Settings:
     SATURN_BASE_URL: str
     SATURN_VERSION: str
 
-    async def __init__(self):
+    def __init__(self):
         try:
             self.SATURN_BASE_URL = os.environ["SATURN_BASE_URL"]
         except KeyError as err:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -54,6 +54,7 @@ class Settings:
 
     @property
     def is_prefect(self) -> bool:
+        """Whether the resource that the cluster will attach to is a prefect flow (or flow run)"""
         return os.environ.get("SATURN_RESOURCE_TYPE", "SingleUserServer").startswith("Prefect")
 
     @property

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -7,7 +7,7 @@ import os
 from urllib.parse import urlparse
 from ._version import get_versions
 
-__version__ = get_versions()["version"]
+__version__ = "0.4.0" # get_versions()["version"]
 
 
 class Settings:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -4,6 +4,7 @@ Settings used for interacting with Saturn
 
 import os
 
+from distutils.version import LooseVersion
 from urllib.parse import urlparse
 from ._version import get_versions
 
@@ -44,7 +45,7 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = os.environ.get("SATURN_VERSION", "v2021.07.19-12")
+        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "v2021.07.19-12"))
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -48,6 +48,10 @@ class Settings:
         return os.environ.get("SATURN_IS_INTERNAL", "false").lower() == "false"
 
     @property
+    def is_prefect(self) -> bool:
+        return os.environ.get("SATURN_RESOURCE_TYPE", "SingleUserServer") == "PrefectCloudFlowRun"
+
+    @property
     def url(self):
         """Saturn url"""
         return self.SATURN_BASE_URL
@@ -55,7 +59,12 @@ class Settings:
     @property
     def headers(self):
         """Saturn auth headers"""
+        if not self.is_prefect or os.environ.get("SATURN_ID") is None:
+            extra = {}
+        else:
+            extra = {"X-Prefect-Cloud-Flow-Run-ID": os.environ.get("SATURN_ID")}
         return {
             "Authorization": f"token {self.SATURN_TOKEN}",
             "X-Dask-Saturn-Version": __version__,
+            **extra,
         }


### PR DESCRIPTION
DEV-2442

This PR does a few things that all have to do with successfully creating self-closing dask clusters for individual prefect cloud flow runs. Specifically this PR:

 - ensures that all prefect dask clusters have `autoclose=true`
 - adds the prefectcloudflowrun_id to the body of the post when creating dask clusters.
 - renames `autoclose` to `shutdown_on_close` since that is now an option in regular distributed
 - uses the saturn version from the env vars to only pass new fields when Saturn is at its most recent. This means that this new version of dask-saturn should still work with older versions of Saturn.

## To test this PR

- get on the this branch of saturn dask-cluster-per-run
- change your SATURN_VERSION to "2021.08.16" in .env_deps
- change this https://github.com/saturncloud/saturn/blob/b5eca6c0b74a547f4a593731b72511888ddec3fb/pdc/routes/dask_clusters.py#L386 to `if LooseVersion(version) < LooseVersion("0.3.0"):`
- `make clean run`
- make a prefect agent, start it
- clone the prefect quickstart, 
- edit the start script to pip install dask-saturn from this branch: 
   `pip install git+https://github.com/saturncloud/dask-saturn.git@jsignell/prefect-flow-run`
- start the jupyter 
- create and register a prefect flow
- go to prefect cloud and do a quick run -> run should succeed, should be visible in saturn, dask_cluster should close when done
- go to prefect cloud and do a quick run, then cancel it after the dask cluster has started but before it's done ->  should be visible in saturn, dask_cluster should be closed