### PR TITLE
adding name property to SaturnCluster

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,7 +9,6 @@ import json
 import logging
 import warnings
 import weakref
-import uuid
 
 from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -9,6 +9,7 @@ import json
 import logging
 import warnings
 import weakref
+import uuid
 
 from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
@@ -173,6 +174,7 @@ class SaturnCluster(SpecCluster):
         ``help(SaturnCluster)``.
         """
         log.info("Resetting cluster.")
+
         settings = Settings()
         url = urljoin(settings.url, "api/dask_clusters/reset")
         cluster_config = {
@@ -183,6 +185,7 @@ class SaturnCluster(SpecCluster):
             "nprocs": nprocs,
             "nthreads": nthreads,
         }
+
         # only send kwargs that are explicity set by user
         cluster_config = {k: v for k, v in cluster_config.items() if v is not None}
 
@@ -258,6 +261,13 @@ class SaturnCluster(SpecCluster):
         except ImportError:
             pass
         return response.json()
+
+    @property
+    def name(self) -> str:
+        """
+        Name of the dask cluster
+        """
+        return self._name
 
     # pylint: disable=invalid-overridden-method
     def _start(

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -489,4 +489,3 @@ def list_sizes() -> List[str]:
 def describe_sizes() -> Dict[str, str]:
     """Return a dict of size options with a description."""
     return {size["name"]: size["display"] for size in _options()["size"]}
-    

--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -489,3 +489,4 @@ def list_sizes() -> List[str]:
 def describe_sizes() -> Dict[str, str]:
     """Return a dict of size options with a description."""
     return {size["name"]: size["display"] for size in _options()["size"]}
+    


### PR DESCRIPTION
Addresses an error with dask[complete]>2021.08.01. 

There was a change to how the cluster widget was rendered in 2021.09.0 - it now requires a name. This adds that property so the widget renders properly and without error.

For DEV-2854
