### PR TITLE
Update publish action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,17 +1,16 @@
-name: Publish dask-saturn to PyPI
+name: Publish to PyPI
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - published
 jobs:
   build-and-publish:
-    name: Build and publish dask-saturn to PyPI
+    name: Build and publish to PyPI
     runs-on: ubuntu-18.04
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
     - name: Install build dependencies
@@ -29,9 +28,9 @@ jobs:
         sdist
         bdist_wheel
     - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.3.0
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         # Password is set in GitHub UI to an API secret for pypi
+        # this needs to be added per-repo
         user: __token__
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.pypi_api_key }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,15 @@
-## Releases
+## Releasing
 
-Releases are created by pushing a tag on `main` or `release-*` branch:
+This section describes how to release a new version of `dask-saturn` to PyPi. It is intended only for maintainers.
 
-```
-git tag -a 0.0.3 -m "Release 0.0.3"
-git push --tags
-```
+1. Created and push a tag on `main` or `release-*` branch:
+  
+  ```
+  git tag -a 0.0.3 -m "Release 0.0.3"
+  git push --tags
+  ```
 
-This kicks off a GitHub Action which automatically publishes the package to PyPi. You can access logs for this run on the "Actions" tab in GitHub.
+2. [Create a new release using the GitHub UI](https://github.com/saturncloud/prefect-saturn/releases/new)
+    - the tag should be a version number, like `0.0.3`
+    - choose the target from "recent commits", and select the most recent commit on `main`
+3. Once this release is created, a GitHub Actions build will automatically start. That build publishes a release to PyPi. You can access logs for this build on the "Actions" tab in GitHub.


### PR DESCRIPTION
This PR:
 - uses the template action from https://github.com/saturncloud/.github/blob/main/workflow-templates/publish-to-pypi.yml
 - makes the user publish a release before the github action starts (rather than just pushing a tag)
