### PR TITLE
Remove 'no workers started up' warning

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -353,9 +353,7 @@ class SaturnCluster(SpecCluster):
             log.info("Success!")
         elif "repeat" in output_statuses:
             log.info("Success!")
-        elif len(output_statuses) == 0:
-            log.warning("No workers started up.")
-        else:
+        elif len(output_statuses) > 0:
             log.warning("Registering default plugins failed. Please check logs for more info.")
 
     def _get_info(self) -> Dict[str, Any]:


### PR DESCRIPTION
This happens frequently on main:

![image](https://user-images.githubusercontent.com/4806877/141513883-d3ac3e80-53f3-4218-b85c-505156ac6d5f.png)

This is because it is now more common for workers to spin up after the plugin is registered. That is not an issue.