### PR TITLE
Use packaging rather than distutils to get version

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 import weakref
 
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -302,7 +302,7 @@ class SaturnCluster(SpecCluster):
             "nthreads": nthreads,
         }
 
-        if self.settings.SATURN_VERSION >= LooseVersion("2021.08.16"):
+        if self.settings.SATURN_VERSION >= parse_version("2021.08.16"):
             cluster_config["prefectcloudflowrun_id"] = os.environ.get(
                 "PREFECT__CONTEXT__FLOW_RUN_ID"
             )

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -4,7 +4,7 @@ Settings used for interacting with Saturn
 
 import os
 
-from packaging.version import Version, parse as parse_version
+from packaging.version import InvalidVersion, Version
 from urllib.parse import urlparse
 from ._version import get_versions
 
@@ -45,7 +45,12 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = parse_version(os.environ.get("SATURN_VERSION", "2021.07.19"))
+        version = os.environ.get("SATURN_VERSION", "2021.07.19")
+        try:
+            self.SATURN_VERSION = Version(version)
+        except InvalidVersion:
+            # suffix like `-daily` is not PEP440 compliant. Strip it off.
+            self.SATURN_VERSION = Version(version.split("-")[0])
 
     @property
     def is_external(self) -> bool:

--- a/dask_saturn/settings.py
+++ b/dask_saturn/settings.py
@@ -4,7 +4,7 @@ Settings used for interacting with Saturn
 
 import os
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse as parse_version
 from urllib.parse import urlparse
 from ._version import get_versions
 
@@ -16,7 +16,7 @@ class Settings:
 
     SATURN_TOKEN: str
     SATURN_BASE_URL: str
-    SATURN_VERSION: LooseVersion
+    SATURN_VERSION: Version
 
     def __init__(self):
         try:
@@ -45,7 +45,7 @@ class Settings:
             raise RuntimeError(err_msg) from err
 
         # get the SATURN_VERSION if included, default to the one before field was added.
-        self.SATURN_VERSION = LooseVersion(os.environ.get("SATURN_VERSION", "2021.07.19"))
+        self.SATURN_VERSION = parse_version(os.environ.get("SATURN_VERSION", "2021.07.19"))
 
     @property
     def is_external(self) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 import versioneer
 
-install_requires = ["distributed", "requests", "cryptography"]
+install_requires = ["distributed", "packaging", "requests", "cryptography"]
 
 
 setup(


### PR DESCRIPTION
Since setuptools is now raising a warning, we need to update to using packaging.
