### PR TITLE
Return None from `SaturnCluster.widget`

### DIFF
--- a/dask_saturn/core.py
+++ b/dask_saturn/core.py
@@ -473,6 +473,9 @@ class SaturnCluster(SpecCluster):
         )
         return cls()
 
+    def _widget(self):
+        return None
+
 
 def _options() -> Dict[str, Any]:
     settings = Settings()


### PR DESCRIPTION
This fixes the issue where the Cluster repr raises an error.

Before:
![image](https://user-images.githubusercontent.com/4806877/192789801-b6865d39-5293-49be-aae2-de67f0986dd8.png)


After:
![image](https://user-images.githubusercontent.com/4806877/192789637-302fbb99-eba2-4b66-b98c-e82754fde009.png)
